### PR TITLE
add .travis.yml and .travis/check_init_py.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python: 3.6
+
+install: "pip3 install flake8 mypy"
+script:
+  - flake8 src/
+  - ./.travis/check_init_py.sh src/
+  - MYPYPATH=$(pwd)/src mypy -p ja --no-strict-optional --strict

--- a/.travis/check_init_py.sh
+++ b/.travis/check_init_py.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# All subdirectories of $1 which
+# 1. Are not $1 itself
+# 2. Are not hidden files
+DIRECTORIES=$(find $1 ! -path $1 ! -path '*/\.*' -type d)
+
+for d in $DIRECTORIES; do
+    if [ -f $d/__init__.py ]; then
+        continue
+    fi
+    echo "Directory $d does not contain a file __init__.py!"
+    exit 1
+done


### PR DESCRIPTION
Set up a CI to check code style and type hints.

MyPy seems to require an `__init__.py` file in each source folder, even with the `--namespace-packages` option. So I also added a script to check that each of our directories in `src/` has an `__init__.py` file.

~~Marking this as a draft since we have not all spoken about and agreed on which Python coding style we're going to follow.~~

Fixes #3 