### PR TITLE
use double quotes instead of single quotes in docstrings

### DIFF
--- a/src/ja/common/message.py
+++ b/src/ja/common/message.py
@@ -1,21 +1,21 @@
-'''
+"""
 The Message module provides the necessary interfaces that have to be
 implemented in order for a class to be transferable between the components
 of JobAdder.
-'''
+"""
 from abc import ABC
 
 
 class Serializable(ABC):
-    '''
+    """
     A base class for all objects which can be converted to and from a python
     dictionary. The dictionary should contain only basic python types:
     strings, ints, bytes, doubles, lists and dictionaries.
-    '''
+    """
 
 
 class Message(Serializable):
-    '''
+    """
     A base class for all messages which can be transferred between the
     components of JobAdder.
-    '''
+    """

--- a/src/ja/common/server_command.py
+++ b/src/ja/common/server_command.py
@@ -1,12 +1,12 @@
-'''
+"""
 This module provides the interface which all server commands implement.
-'''
+"""
 from ja.common.message import Message
 
 
 class ServerCommand(Message):
-    '''
+    """
     A base class for all server commands.
     A server command is an action which is performed on the server
     and operates on the database.
-    '''
+    """

--- a/src/ja/server/local_job_adder.py
+++ b/src/ja/server/local_job_adder.py
@@ -1,4 +1,4 @@
-'''
+"""
 LocalJobAdder is a single-class command line program.
 
 It verifies incoming user commands, checks that the user has sufficient
@@ -7,10 +7,10 @@ server socket.
 
 The commands are received on the standard input, and the server response
 will be printed on the standard output.
-'''
+"""
 
 
 class LocalJobAdder:
-    '''
+    """
     The main class of the program.
-    '''
+    """

--- a/src/ja/server/socket_handler.py
+++ b/src/ja/server/socket_handler.py
@@ -1,11 +1,11 @@
-'''
+"""
 This module contains classes and definitions related to handling the local
 server socket where user commands are received.
-'''
+"""
 
 
 class ServerSocketHandler:
-    '''
+    """
     ServerSocketHandler creates the local server socket and then handles all
     requests that are received there.
-    '''
+    """


### PR DESCRIPTION
As we agreed, we should use double quotes.