### PR TITLE
TravisCI: ignore F821 in flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ python: 3.6
 
 install: "pip3 install flake8 mypy"
 script:
-  - flake8 src/
+  - flake8 src/ --ignore F821
   - ./.travis/check_init_py.sh src/
   - MYPYPATH=$(pwd)/src mypy -p ja --no-strict-optional --strict


### PR DESCRIPTION
Why? If you look at https://github.com/DistributedTaskScheduling/JobAdder/pull/18, you will see that the build fails, because flake8 reports some types as not defined. However, they are defined - on the line above! I think this is a bug in flake8 because MyPy does not report any error and MyPy also does check for undefined types.

I will open an issue in flake8 and see how it goes, but in the meantime we can just disable the check.