### PR TITLE
travis.yml: fix max line length setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ python: 3.6
 
 install: "pip3 install flake8 mypy"
 script:
-  - flake8 src/ --ignore F821 --config max-line-length 120
+  - flake8 src/ --ignore F821 --max-line-length=120
   - ./.travis/check_init_py.sh src/
   - MYPYPATH=$(pwd)/src mypy -p ja --no-strict-optional --strict


### PR DESCRIPTION
I don't know what happened the first time, but I got it wrong. It should be `--max-line-length=120`, not `--config max-line-length 120`

Basically fixes #22
PS: this time, somebody please test that I haven't done something stupid again :)