### PR TITLE
PlantUML image size limit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ uml:
 	mkdir -p build
 	./doctools/py-puml-tools/py2puml/py2puml.py -r src/ --recursive src/__init__.py -c ./doctools/py2puml.ini > build/project.puml
 	mv py2puml.log build/py2puml.log
-	plantuml docs/main.puml -o ../build/
+	plantuml -DPLANTUML_LIMIT_SIZE=100000 docs/main.puml -o ../build/
 
 doxygen:
 	doxygen doctools/Doxyfile


### PR DESCRIPTION
It seems we forgot to override the PlantUML image size limit of 2048x2048.
This PR fixes that.