### PR TITLE
tests: use paths relative to the test itself

### DIFF
--- a/src/test/worker/test_docker_interface.py
+++ b/src/test/worker/test_docker_interface.py
@@ -39,7 +39,7 @@ class DockerInterfaceTest(TestCase):
     """
     def setUp(self) -> None:
         self._docker_interface = DockerInterface(server_proxy=WorkerServerProxyDummy(wmcs=dict(), jobs=dict()))
-        self._mount_point_source_path = os.path.abspath(os.getcwd()) + "/test/worker/mount_directory/"
+        self._mount_point_source_path = os.path.dirname(os.path.abspath(__file__)) + "/mount_directory/"
         generic_job_dict = {
             "status": 0,
             "owner_id": os.getuid(),


### PR DESCRIPTION
Relying on the current directory may break if we run tests from different directories.

I had a problem on my computer since I run the tests a little bit differently than the CI :)
Also, I think we need to specify which docker version we need. For example, I had docker 1.13 or something like that, and it wasn't working. @JohannesGaessler Do you know which minimum version we need?