### PR TITLE
Timeout for work machines and server

### DIFF
--- a/src/ja/common/proxy/proxy.py
+++ b/src/ja/common/proxy/proxy.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from ja.common.proxy.ssh import SSHConfig, ISSHConnection
+from ja.common.proxy.ssh import SSHConfig, ISSHConnection, SSHConnection
 
 
 class Proxy(ABC):
@@ -11,7 +11,7 @@ class Proxy(ABC):
     """
     @abstractmethod
     def _get_ssh_connection(self, ssh_config: SSHConfig) -> ISSHConnection:
-        pass
+        return SSHConnection(ssh_config=ssh_config, remote_module=None)
 
 
 class SingleMessageProxy(Proxy, ABC):

--- a/src/ja/server/dispatcher/dispatcher.py
+++ b/src/ja/server/dispatcher/dispatcher.py
@@ -1,8 +1,10 @@
 from ja.common.job import JobStatus
 from ja.server.database.database import ServerDatabase
 from ja.server.database.types.job_entry import DatabaseJobEntry
+from ja.server.database.types.work_machine import WorkMachine
 from ja.server.dispatcher.proxy_factory import WorkerProxyFactoryBase
-from typing import Dict
+from typing import Dict, List
+from paramiko.ssh_exception import SSHException  # type: ignore
 
 import logging
 logger = logging.getLogger(__name__)
@@ -22,6 +24,7 @@ class Dispatcher:
         """
         self._proxy_factory = proxy_factory
         self._previous_statuses: Dict[str, JobStatus] = dict()
+        self._lost_work_machines: List[WorkMachine] = []
 
     _job_status_order = [JobStatus.QUEUED, JobStatus.CANCELLED, JobStatus.PAUSED, JobStatus.RUNNING]
 
@@ -35,39 +38,66 @@ class Dispatcher:
 
         return Dispatcher._job_status_order.index(job.job.status)
 
-    def set_distribution(self, job_distribution: JobDistribution) -> None:
+    def set_distribution(self, job_distribution: JobDistribution) -> List[WorkMachine]:
         """!
         Distributes the newly added jobs to the work machines.
         and potentially pauses jobs that need to be paused.
 
         @param job_distribution the new job distribution.
+        @return a list of all work machines that the server has lost connection to.
         """
         logger.debug("Dispatching jobs")
         new_statuses: Dict[str, JobStatus] = dict()
+
+        self._lost_work_machines.clear()
         for job_entry in sorted(job_distribution, key=self._sort_key_function):
             job = job_entry.job
-
             if job.status == JobStatus.QUEUED:
                 logger.debug("Job %s queued." % job.uid)
                 continue
 
             work_machine = job_entry.assigned_machine
+            proxy = self._proxy_factory.get_proxy(work_machine)
+
             logger.debug("Job %s with status %s on %s." % (job.uid, job.status.name, work_machine.uid))
+            proxy = self._proxy_factory.get_proxy(work_machine)
+            try:
+                proxy.check_connection()
+            except SSHException:
+                self._timeout(job_entry)
             previous_status = self._previous_statuses.get(job.uid, None)
             if previous_status is None or job.status != previous_status:
-                proxy = self._proxy_factory.get_proxy(work_machine)
-                if job.status == JobStatus.RUNNING:
-                    if previous_status is None or previous_status == JobStatus.QUEUED:
-                        proxy.dispatch_job(job)
-                    elif previous_status == JobStatus.PAUSED:
-                        proxy.resume_job(job.uid)
-                    new_statuses[job.uid] = job.status
-                elif job.status == JobStatus.CANCELLED:
-                    proxy.cancel_job(job.uid)  # Do not add job back to self._previous_statuses
-                elif job.status == JobStatus.PAUSED:
-                    proxy.pause_job(job.uid)
-                    new_statuses[job.uid] = job.status
+                try:
+                    if job.status == JobStatus.RUNNING:
+                        if previous_status is None or previous_status == JobStatus.QUEUED:
+                            proxy.dispatch_job(job)
+                        elif previous_status == JobStatus.PAUSED:
+                            proxy.resume_job(job.uid)
+                        new_statuses[job.uid] = job.status
+                    elif job.status == JobStatus.CANCELLED:
+                        proxy.cancel_job(job.uid)  # Do not add job back to self._previous_statuses
+                    elif job.status == JobStatus.PAUSED:
+                        proxy.pause_job(job.uid)
+                        new_statuses[job.uid] = job.status
+                    else:
+                        raise ValueError("Received unexpected state %s for job with UID %s." %
+                                         (job.status.name, job.uid))
+                except SSHException:
+                    self._timeout(job_entry)
             else:
-                new_statuses[job.uid] = job.status
+                # If the job status hasn't changed, try to ping the machine to make sure it is not dead.
+                try:
+                    proxy.check_connection()
+                    new_statuses[job.uid] = job.status
+                except SSHException:
+                    self._timeout(job_entry)
 
         self._previous_statuses = new_statuses
+        return self._lost_work_machines
+
+    def _timeout(self, entry: DatabaseJobEntry) -> None:
+        if any(machine.uid == entry.assigned_machine.uid for machine in self._lost_work_machines):
+            return
+
+        logger.error("Lost connection to Work machine with id %s." % entry.assigned_machine.uid)
+        self._lost_work_machines.append(entry.assigned_machine)

--- a/src/ja/server/proxy/proxy.py
+++ b/src/ja/server/proxy/proxy.py
@@ -53,6 +53,12 @@ class IWorkerProxy(ContinuousProxy, ABC):
         @return: The Response from the worker client.
         """
 
+    @abstractmethod
+    def check_connection(self) -> None:
+        """!
+        Tries to connect to the work machine and throws and exception if it could not.
+        """
+
 
 class WorkerProxyBase(IWorkerProxy, ABC):
     """
@@ -102,6 +108,9 @@ class WorkerProxyBase(IWorkerProxy, ABC):
         response = self._ssh_connection.send_command(command)
         logger.debug("response from the worker: %s" % str(response))
         return response
+
+    def check_connection(self) -> None:
+        self._ssh_connection.send_dummy_command()
 
 
 class WorkerProxy(WorkerProxyBase):

--- a/src/test/proxy/worker_proxy.py
+++ b/src/test/proxy/worker_proxy.py
@@ -23,6 +23,9 @@ class SSHDummyWorkerProxy(WorkerProxyBase):
     def _get_ssh_connection(self, ssh_config: SSHConfig) -> ISSHConnection:
         return SSHConnectionDummy(socket_path="./dummy_socket_%s" % ssh_config.hostname)
 
+    def check_connection(self) -> None:
+        pass
+
 
 class WorkerCommandHandlerDummy(ThreadedCommandHandler):
 

--- a/src/test/proxy/worker_proxy_dummy.py
+++ b/src/test/proxy/worker_proxy_dummy.py
@@ -26,6 +26,9 @@ class WorkerProxyDummy(IWorkerProxy):
     def _get_ssh_connection(self, ssh_config: SSHConfig) -> ISSHConnection:
         pass
 
+    def check_connection(self) -> None:
+        pass
+
     def _find_job(self, uid: str) -> Job:
         for job in self._jobs:
             if job.uid == uid:

--- a/src/test/server/scheduler/test_scheduler.py
+++ b/src/test/server/scheduler/test_scheduler.py
@@ -47,12 +47,42 @@ class MockDispatcher(Dispatcher):
         self._expect = expect_schedule
         self.count_called = 0
 
-    def set_distribution(self, job_distribution: ServerDatabase.JobDistribution) -> None:
+    def set_distribution(self, job_distribution: ServerDatabase.JobDistribution) -> List[WorkMachine]:
         self.count_called += 1
         assert_distributions_equal(self._test_case, job_distribution, self._expect)
+        return []
+
+
+class MockDispatcherOffline(Dispatcher):
+    def set_distribution(self, job_distribution: ServerDatabase.JobDistribution) -> List[WorkMachine]:
+        return [entry.assigned_machine for entry in job_distribution]
 
 
 class SchedulerTest(TestCase):
+    def test_offline_machine(self) -> None:
+        db = MockDatabase()
+
+        machine = get_machine(8, 8, 8)
+        machine.resources.allocate(ResourceAllocation(8, 8, 0))
+        db.update_work_machine(machine)
+        job = get_job(machine=machine, cpu=8, ram=8)
+        db.update_job(job.job)
+        job.job.status = JobStatus.RUNNING
+        db.update_job(job.job)
+        db.assign_job_machine(job.job, job.assigned_machine)
+        current_schedule = [job]
+
+        algo = MockAlgorithm(self, current_schedule, [machine], {}, [job])
+        dispatcher = MockDispatcherOffline(None)
+        scheduler = Scheduler(algo, dispatcher, {})
+        scheduler.reschedule(db)
+        job_entries = db.query_jobs(None, -1, None)
+        self.assertEqual(len(job_entries), 1)
+        self.assertEqual(job_entries[0].assigned_machine, None)
+        self.assertEqual(job_entries[0].job.status, JobStatus.CRASHED)
+        wms = db.get_all_work_machines()
+        self.assertEqual(wms[0].state, WorkMachineState.OFFLINE)
+
     def test_scheduler_updates(self) -> None:
         db = MockDatabase()
 

--- a/src/test/ssh/test_ssh_dummy.py
+++ b/src/test/ssh/test_ssh_dummy.py
@@ -32,6 +32,9 @@ class SSHConnectionDummy(ISSHConnection):
     def close(self) -> None:
         pass
 
+    def send_dummy_command(self) -> None:
+        pass
+
 
 class ServerCommandDummy(ServerCommand):
     def __init__(self, payload: str):


### PR DESCRIPTION
Marks work machines as offline whenever the **Dispatcher** could not send it's commands in due time (120 secs) and informs the user if a connection to the server couldn't be established.

fixes #106 