### PR TITLE
messages: add effective_user for user messages

### DIFF
--- a/src/ja/common/message/server.py
+++ b/src/ja/common/message/server.py
@@ -15,13 +15,10 @@ class ServerCommand(Command, ABC):
     sent by a user client or the worker client and performed on the server.
     ServerCommands typically operate on the server database.
     """
-
     @abstractmethod
     def execute(self, database: "ServerDatabase") -> Response:
         """!
-        Executes a ServerCommand object on the server and generates a
-        Response object to be sent back in return.
-        @param database: The ServerDatabase object to execute the ServerCommand
-        on.
+        Executes a ServerCommand object on the server and generates a Response object to be sent back in return.
+        @param database: The ServerDatabase object to execute the ServerCommand on.
         @return: The Response to be sent back.
         """

--- a/src/ja/user/message/add.py
+++ b/src/ja/user/message/add.py
@@ -33,6 +33,9 @@ class AddCommand(UserServerCommand):
 
     def execute(self, database: ServerDatabase) -> Response:
         job: Job = self.config.job
+        if job.owner_id == -1:
+            job.owner_id = self.effective_user
+
         if self.effective_user != 0 and self.effective_user != job.owner_id:
             return Response(result_string="Cannot submit jobs for other users.", is_success=False)
 

--- a/src/ja/user/message/add.py
+++ b/src/ja/user/message/add.py
@@ -1,5 +1,5 @@
 from typing import Dict
-from ja.common.message.server import ServerCommand
+from ja.user.message.base import UserServerCommand
 from ja.common.message.base import Response
 from ja.server.database.database import ServerDatabase
 from ja.user.config.add import AddCommandConfig
@@ -7,7 +7,7 @@ from ja.common.job import Job, JobStatus
 from ja.server.database.types.job_entry import DatabaseJobEntry
 
 
-class AddCommand(ServerCommand):
+class AddCommand(UserServerCommand):
     """
     Command for adding a job.
     """
@@ -33,6 +33,9 @@ class AddCommand(ServerCommand):
 
     def execute(self, database: ServerDatabase) -> Response:
         job: Job = self.config.job
+        if self.effective_user != 0 and self.effective_user != job.owner_id:
+            return Response(result_string="Cannot submit jobs for other users.", is_success=False)
+
         db_job_id: DatabaseJobEntry = database.find_job_by_id(job.uid)
         if db_job_id is not None:
             return Response(result_string="Job with id %s already exists" % job.uid,

--- a/src/ja/user/message/base.py
+++ b/src/ja/user/message/base.py
@@ -1,0 +1,14 @@
+from ja.common.message.server import ServerCommand
+
+
+class UserServerCommand(ServerCommand):
+    def __init__(self) -> None:
+        self._effective_user: int = -1
+
+    @property
+    def effective_user(self) -> int:
+        return self._effective_user
+
+    @effective_user.setter
+    def effective_user(self, user: int) -> None:
+        self._effective_user = user

--- a/src/ja/user/message/query.py
+++ b/src/ja/user/message/query.py
@@ -1,5 +1,5 @@
 from ja.common.message.base import Response
-from ja.common.message.server import ServerCommand
+from ja.user.message.base import UserServerCommand
 from ja.user.config.base import UserConfig
 from ja.common.job import JobPriority, JobStatus
 from datetime import datetime
@@ -8,7 +8,7 @@ from ja.server.database.types.job_entry import DatabaseJobEntry
 from ja.server.database.database import ServerDatabase
 
 
-class QueryCommand(ServerCommand):
+class QueryCommand(UserServerCommand):
     """
     Command for querying the server.
     """

--- a/src/test/serializable/user_commands/add.py
+++ b/src/test/serializable/user_commands/add.py
@@ -1,0 +1,29 @@
+from ja.server.database.sql.mock_database import MockDatabase
+from ja.user.message.add import AddCommand
+from ja.user.config.base import UserConfig
+from ja.user.config.add import AddCommandConfig
+from ja.common.job import JobStatus
+from test.server.scheduler.common import get_job
+from unittest import TestCase
+
+
+class AddCommandTest(TestCase):
+    """
+    Class for testing CancelCommandConfig.
+    """
+
+    def setUp(self) -> None:
+        self._db = MockDatabase()
+        self._job = get_job(user=1, status=JobStatus.NEW).job
+        self._job.uid = "1"  # Should be removed
+        self._cmd = AddCommand(AddCommandConfig(UserConfig(), self._job))
+
+    def test_admin_can_add_for_other_user(self) -> None:
+        self._cmd.effective_user = 0
+        response = self._cmd.execute(self._db)
+        self.assertTrue(response.is_success)
+
+    def test_add_insufficient_permission(self) -> None:
+        self._cmd.effective_user = 2
+        response = self._cmd.execute(self._db)
+        self.assertFalse(response.is_success)

--- a/src/test/server/test_command_handler.py
+++ b/src/test/server/test_command_handler.py
@@ -3,8 +3,10 @@ from ja.common.message.server import ServerCommand
 from ja.server.database.database import ServerDatabase
 from ja.server.proxy.command_handler import ServerCommandHandler
 from ja.worker.message.base import WorkerServerCommand
+from ja.user.message.base import UserServerCommand
 
 import grp
+import pwd
 from typing import Dict, List, Type, cast
 from unittest import TestCase
 from unittest.mock import MagicMock
@@ -29,17 +31,25 @@ class MockCommand(WorkerServerCommand):
         return MockCommand(cast(str, dct["user"]))
 
 
+class UserMockCommand(UserServerCommand):
+    def to_dict(self) -> Dict[str, object]:
+        return {}
+
+    def execute(self, db: ServerDatabase) -> Response:
+        pass
+
+    @classmethod
+    def from_dict(cls, dct: Dict[str, object]) -> "UserMockCommand":
+        return UserMockCommand()
+
+
 class ServerCommandHandlerNoExecute(ServerCommandHandler):
 
     # Override user/worker commands.
     # Otherwise, to test a user command we need to create a full SSH Config, Command config, etc.
     _user_commands = {
-        "SecureCommand": MockCommand,
-        "UnsecureCommand": MockCommand,
+        "UserCommand": UserMockCommand
     }
-
-    # User commands which can be run by everybody
-    _unsecured_user_commands = ["UnsecureCommand"]
 
     _worker_commands = {
         "WorkerCommand": cast(Type[WorkerServerCommand], MockCommand),
@@ -50,15 +60,22 @@ class ServerCommandHandlerNoExecute(ServerCommandHandler):
         self._admin_group = admin_group
         self._execute_count = 0
         self._running = True
+        self._user = -1
         self.response: Dict[str, object] = {}
 
     def _execute_command(self, command: ServerCommand) -> Dict[str, object]:
+        if self._user >= 0:
+            self._test.assertEquals(self._user, cast(UserServerCommand, command).effective_user)
+
         self._test.assertIsNotNone(command)
         self._execute_count += 1
         return self.response
 
     def assert_called(self, times: int) -> None:
-        self._test.assertEqual(self._execute_count, times)
+        self._test.assertEquals(self._execute_count, times)
+
+    def set_expect_user(self, user: int) -> None:
+        self._user = user
 
 
 class MockGroup:
@@ -67,9 +84,29 @@ class MockGroup:
         self.gr_name = name
 
 
+class MockPwd:
+    def __init__(self, uid: int):
+        self._uid = uid
+
+    @property
+    def pw_uid(self) -> int:
+        return self._uid
+
+
+def mock_pwnam(user: str) -> MockPwd:
+    if user == "root":
+        return MockPwd(0)
+    if user == "user1":
+        return MockPwd(1)
+    if user == "user2":
+        return MockPwd(2)
+    return None
+
+
 class ServerCommandHandlerTest(TestCase):
     def setUp(self) -> None:
         grp.getgrall = MagicMock(return_value=[MockGroup("root", ["user1"]), MockGroup("users", ["user2"])])
+        pwd.getpwnam = MagicMock(side_effect=mock_pwnam)
         self._handler = ServerCommandHandlerNoExecute(self, "root")
 
     def test_admin_checks(self) -> None:
@@ -80,29 +117,17 @@ class ServerCommandHandlerTest(TestCase):
 
     def test_user_message(self) -> None:
         self._handler.response = {"status": "ACK"}
-        response = self._handler._process_command_dict({"user": "user1"}, "UnsecureCommand", "user2")
-        self._handler.assert_called(1)
-        self.assertDictEqual(response, self._handler.response)
-
-    def test_user_message_same_owner(self) -> None:
-        self._handler.response = {"status": "ACK"}
-        response = self._handler._process_command_dict({"user": "user2"}, "SecureCommand", "user2")
+        self._handler.set_expect_user(2)
+        response = self._handler._process_command_dict({}, "UserCommand", "user2")
         self._handler.assert_called(1)
         self.assertDictEqual(response, self._handler.response)
 
     def test_user_message_admin(self) -> None:
         self._handler.response = {"status": "ACK"}
-        response = self._handler._process_command_dict({"user": "user2"}, "SecureCommand", "root")
+        self._handler.set_expect_user(0)
+        response = self._handler._process_command_dict({}, "UserCommand", "root")
         self._handler.assert_called(1)
         self.assertDictEqual(response, self._handler.response)
-
-    def test_user_message_no_permission(self) -> None:
-        response = self._handler._process_command_dict({"user": "user1"}, "SecureCommand", "user2")
-        parsed_response = Response.from_dict(response)
-        self._handler.assert_called(0)
-        self.assertFalse(parsed_response.is_success, False)
-        self.assertEqual(parsed_response.result_string,
-                         self._handler._INSUFFICIENT_PERM_TEMPLATE % ("user2", "SecureCommand"))
 
     def test_worker_message(self) -> None:
         self._handler.response = {"status": "ACK"}
@@ -115,15 +140,15 @@ class ServerCommandHandlerTest(TestCase):
         parsed_response = Response.from_dict(response)
         self._handler.assert_called(0)
         self.assertFalse(parsed_response.is_success, False)
-        self.assertEqual(parsed_response.result_string,
-                         self._handler._INSUFFICIENT_PERM_TEMPLATE % ("user2", "WorkerCommand"))
+        self.assertEquals(parsed_response.result_string,
+                          self._handler._INSUFFICIENT_PERM_TEMPLATE % ("user2", "WorkerCommand"))
 
     def test_invalid_message(self) -> None:
         response = self._handler._process_command_dict({"user": "user2"}, "Bad", "user2")
         parsed_response = Response.from_dict(response)
         self._handler.assert_called(0)
         self.assertFalse(parsed_response.is_success, False)
-        self.assertEqual(parsed_response.result_string, self._handler._UNKNOWN_COMMAND_TEMPLATE % "Bad")
+        self.assertEquals(parsed_response.result_string, self._handler._UNKNOWN_COMMAND_TEMPLATE % "Bad")
 
     def test_kill_ok(self) -> None:
         response = self._handler._process_command_dict({"user": "root"}, "KillCommand", "root")


### PR DESCRIPTION
Fixes #126

I decided it makes the most sense to add a base class for all user messages where I can set the effective user for each command. This seemed the easiest way to add it, without having to change many tests.