### PR TITLE
Fixed bug in database.

### DIFF
--- a/src/ja/server/database/database.py
+++ b/src/ja/server/database/database.py
@@ -60,7 +60,7 @@ class ServerDatabase(ABC):
     @abstractmethod
     def get_work_machines(self) -> List[WorkMachine]:
         """!
-        @return A list of online work machines.
+        @return A list of online and retired work machines.
         """
 
     JobDistribution = List[DatabaseJobEntry]

--- a/src/ja/server/database/sql/database.py
+++ b/src/ja/server/database/sql/database.py
@@ -71,7 +71,8 @@ class SQLDatabase(ServerDatabase):
             mapper(WorkMachine, work_machine, properties={
                 "_resources": relationship(WorkMachineResources, uselist=False),
                 "_ssh_config": relationship(SSHConfig, uselist=False),
-                "uid": synonym("_uid", descriptor=WorkMachine.uid)
+                "uid": synonym("_uid", descriptor=WorkMachine.uid),
+                "state": synonym("_state", descriptor=WorkMachine.state)
             })
 
             mount_point = Table("mount_point", metadata,
@@ -265,7 +266,8 @@ class SQLDatabase(ServerDatabase):
 
     def get_work_machines(self) -> Optional[List[WorkMachine]]:
         session = self.scoped()
-        work_machines: Optional[List[WorkMachine]] = session.query(WorkMachine).options(joinedload("*")).all()
+        work_machines: Optional[List[WorkMachine]] = session.query(WorkMachine).filter(
+            WorkMachine.state != WorkMachineState.OFFLINE).options(joinedload("*")).all()
         return work_machines
 
     def get_current_schedule(self) -> Optional[ServerDatabase.JobDistribution]:

--- a/src/test/server/database/test_database.py
+++ b/src/test/server/database/test_database.py
@@ -119,7 +119,7 @@ class DatabaseTest(TestCase):
     def test_update_work_machine(self) -> None:
         self.mockDatabase.update_work_machine(self.work_machine)
         self.assertEqual(self.mockDatabase.get_work_machines()[0], self.work_machine)
-        work_machine2 = WorkMachine("machi1", WorkMachineState.OFFLINE,
+        work_machine2 = WorkMachine("machi1", WorkMachineState.ONLINE,
                                     WorkMachineResources(ResourceAllocation(12, 32, 12)))
         self.mockDatabase.update_work_machine(work_machine2)
         self.assertEqual(self.mockDatabase.get_work_machines()[0], work_machine2)
@@ -221,6 +221,13 @@ class DatabaseTest(TestCase):
         self.job.status = JobStatus.QUEUED
         self.mockDatabase.update_job(self.job)
         call.assert_called_once_with(self.job)
+
+    def test_get_work_machine(self) -> None:
+        self.mockDatabase.update_work_machine(self.work_machine)
+        work_machine = WorkMachine("coronaRIP", WorkMachineState.OFFLINE,
+                                   WorkMachineResources(ResourceAllocation(2, 2, 2)))
+        self.mockDatabase.update_work_machine(work_machine)
+        self.assertEqual(self.mockDatabase.get_work_machines(), [self.work_machine])
 
     count: int = 0
 


### PR DESCRIPTION
get_work_machines was returning all machines not only the ones that were ONLINE.