### PR TITLE
Nonroot daemons

### DIFF
--- a/data/bin/JobAdderServer.service
+++ b/data/bin/JobAdderServer.service
@@ -5,6 +5,7 @@ After=postgresql.service
 AssertPathExists=
 
 [Service]
+User=jobadder
 ExecStart=/usr/bin/ja-server
 ExecStop=/usr/bin/bash -c "/usr/bin/ja-server -k && tail --pid=$MAINPID -f /dev/null"
 

--- a/data/bin/JobAdderServer.service
+++ b/data/bin/JobAdderServer.service
@@ -6,8 +6,7 @@ AssertPathExists=
 
 [Service]
 ExecStart=/usr/bin/ja-server
-# Wait 2s for the server to stop.
-ExecStop=/usr/bin/bash -c '/usr/bin/ja-server -k && sleep 2'
+ExecStop=/usr/bin/bash -c "/usr/bin/ja-server -k && tail --pid=$MAINPID -f /dev/null"
 
 [Install]
 WantedBy=multi-user.target

--- a/data/bin/JobAdderWorker.service
+++ b/data/bin/JobAdderWorker.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=JobAdder Worker Daemon
+Requires=docker.service
+After=docker.service
+AssertPathExists=
+
+[Service]
+ExecStart=/usr/bin/ja-worker
+ExecStop=/usr/bin/bash -c "/usr/bin/ja-worker -k && tail --pid=$MAINPID -f /dev/null"
+
+[Install]
+WantedBy=multi-user.target

--- a/data/bin/JobAdderWorker.service
+++ b/data/bin/JobAdderWorker.service
@@ -5,6 +5,7 @@ After=docker.service
 AssertPathExists=
 
 [Service]
+User=jobadder
 ExecStart=/usr/bin/ja-worker
 ExecStop=/usr/bin/bash -c "/usr/bin/ja-worker -k && tail --pid=$MAINPID -f /dev/null"
 

--- a/data/bin/ja-server
+++ b/data/bin/ja-server
@@ -9,8 +9,9 @@ class ServerCLI(SimpleDaemonCLIInterface):
     def socket_name(self) -> str:
         return "/tmp/jobadder-server.socket"
 
-    def run_main(self) -> None:
-        JobCenter().run()
+    def run_main(self, config_file: str) -> None:
+        jc = JobCenter(config_file=config_file) if config_file else JobCenter()
+        jc.run()
 
 
 if __name__ == "__main__":

--- a/data/bin/ja-server
+++ b/data/bin/ja-server
@@ -7,7 +7,7 @@ from ja.server.main import JobCenter
 class ServerCLI(SimpleDaemonCLIInterface):
     @property
     def socket_name(self) -> str:
-        return "/run/jobadder-server.socket"
+        return "/tmp/jobadder-server.socket"
 
     def run_main(self) -> None:
         JobCenter().run()

--- a/data/bin/ja-worker
+++ b/data/bin/ja-worker
@@ -9,8 +9,14 @@ class WorkerCLI(SimpleDaemonCLIInterface):
     def socket_name(self) -> str:
         return "/tmp/jobadder-worker.socket"
 
-    def run_main(self) -> None:
-        JobWorker(remote_module="/tmp/jobadder-server.socket", command_string="ja-remote %s").run()
+    def run_main(self, config_file: str) -> None:
+        jw: JobWorker = None
+        if config_file:
+            jw = JobWorker(config_path=config_file, remote_module="/tmp/jobadder-server.socket",
+                           command_string="ja-remote %s")
+        else:
+            jw = JobWorker(remote_module="/tmp/jobadder-server.socket", command_string="ja-remote %s")
+        jw.run()
 
 
 if __name__ == "__main__":

--- a/data/bin/ja-worker
+++ b/data/bin/ja-worker
@@ -7,10 +7,10 @@ from ja.worker.main import JobWorker
 class WorkerCLI(SimpleDaemonCLIInterface):
     @property
     def socket_name(self) -> str:
-        return "/run/jobadder-worker.socket"
+        return "/tmp/jobadder-worker.socket"
 
     def run_main(self) -> None:
-        JobWorker(remote_module="/run/jobadder-server.socket", command_string="ja-remote %s").run()
+        JobWorker(remote_module="/tmp/jobadder-server.socket", command_string="ja-remote %s").run()
 
 
 if __name__ == "__main__":

--- a/data/config-files/server.conf
+++ b/data/config-files/server.conf
@@ -1,4 +1,4 @@
-admin_group: root
+admin_group: jobadder
 database_config:
         host: 127.0.0.1
         port: 1

--- a/data/config-files/worker.conf
+++ b/data/config-files/worker.conf
@@ -1,0 +1,10 @@
+ssh_config:
+        hostname: '<serverip>'
+        username: jobadder
+        password: jobadder
+resource_allocation:
+        cpu_threads: 1
+        memory: 1
+        swap: 1
+uid: worker0
+admin_group: jobadder

--- a/install.sh
+++ b/install.sh
@@ -33,14 +33,20 @@ cd $SCRIPTPATH
 
 # Install Systemd unit files
 SERVER_SRV_FILE=/etc/systemd/system/JobAdderServer.service
+WORKER_SRV_FILE=/etc/systemd/system/JobAdderWorker.service
 
-cp ./data/bin/JobAdderServer.service $SERVER_SRV_FILE
-chmod 644 $SERVER_SRV_FILE
+install ./data/bin/JobAdderServer.service $SERVER_SRV_FILE -m 644
+install ./data/bin/JobAdderWorker.service $WORKER_SRV_FILE -m 644
 
 # Install config file
-CONFIG_FILE=/etc/jobadder/server.conf
+SERVER_CONFIG_FILE=/etc/jobadder/server.conf
+WORKER_CONFIG_FILE=/etc/jobadder/worker.conf
 
-if [ ! -f $CONFIG_FILE ]; then
+if [ ! -f $SERVER_CONFIG_FILE ]; then
     mkdir -p /etc/jobadder/
-    install ./data/config-files/server.conf $CONFIG_FILE -m 644
+    install ./data/config-files/server.conf $SERVER_CONFIG_FILE -m 644
+fi
+
+if [ ! -f $WORKER_CONFIG_FILE ]; then
+    install ./data/config-files/worker.conf $WORKER_CONFIG_FILE -m 644
 fi

--- a/src/ja/common/cli_util.py
+++ b/src/ja/common/cli_util.py
@@ -9,12 +9,13 @@ import yaml
 class SimpleDaemonCLIInterface:
     def __init__(self) -> None:
         parser = ArgumentParser()
-        parser.add_argument("-k", "--kill", help="Shut down the job adder server.", action="store_true")
+        parser.add_argument("-k", "--kill", help="Shut down the job adder daemon.", action="store_true")
+        parser.add_argument("-c", "--config", help="Configuration file to use.", type=str)
         args = parser.parse_args()
         if args.kill:
             self._kill_daemon()
         else:
-            self.run_main()
+            self.run_main(args.config)
 
     def _kill_daemon(self) -> None:
         # We construct a fake message and send it to the daemon.
@@ -37,7 +38,9 @@ class SimpleDaemonCLIInterface:
         pass
 
     @abstractmethod
-    def run_main(self) -> None:
+    def run_main(self, config_file: str) -> None:
         """
         Run the main class of the component.
+
+        @param config_file The config file specified on the command line, or None.
         """

--- a/src/ja/server/main.py
+++ b/src/ja/server/main.py
@@ -49,7 +49,7 @@ class JobCenter:
             machine.state = WorkMachineState.OFFLINE
             self._database.update_work_machine(machine)
 
-    def __init__(self, socket_path: str = "/run/jobadder-server.socket", database_name: str = "jobadder") -> None:
+    def __init__(self, socket_path: str = "/tmp/jobadder-server.socket", database_name: str = "jobadder") -> None:
         """!
         Initialize the JobAdder server daemon.
         This includes:

--- a/src/ja/server/main.py
+++ b/src/ja/server/main.py
@@ -33,9 +33,9 @@ class JobCenter:
                                           dp.DefaultPreemptiveDistributionPolicy(cost_function))
 
     @staticmethod
-    def _read_config() -> ServerConfig:
-        with open("/etc/jobadder/server.conf") as f:
-            logger.info("reading /etc/jobadder/server.conf config file")
+    def _read_config(config_file: str) -> ServerConfig:
+        with open(config_file) as f:
+            logger.info("reading %s config file" % config_file)
             return ServerConfig.from_string(f.read())
 
     def _cleanup(self) -> None:
@@ -49,7 +49,8 @@ class JobCenter:
             machine.state = WorkMachineState.OFFLINE
             self._database.update_work_machine(machine)
 
-    def __init__(self, socket_path: str = "/tmp/jobadder-server.socket", database_name: str = "jobadder") -> None:
+    def __init__(self, config_file: str = "/etc/jobadder/server.conf",
+                 socket_path: str = "/tmp/jobadder-server.socket", database_name: str = "jobadder") -> None:
         """!
         Initialize the JobAdder server daemon.
         This includes:
@@ -57,11 +58,12 @@ class JobCenter:
         2. Connecting to the configured database.
         3. Initializing the scheduler and the dispatcher.
         4. Starting the web server and the email notifier.
+        @param config_file: the configuration file to use.
         @param socket_path: the path to the unix named socket for the command handler to listen on.
         @param database_name: the name of the database to use.
         """
 
-        config = self._read_config()
+        config = self._read_config(config_file)
         self._database = SQLDatabase(host=config.database_config.host,
                                      user=config.database_config.username,
                                      password=config.database_config.password,

--- a/src/ja/server/proxy/proxy.py
+++ b/src/ja/server/proxy/proxy.py
@@ -110,5 +110,5 @@ class WorkerProxy(WorkerProxyBase):
     """
     def _get_ssh_connection(self, ssh_config: SSHConfig) -> ISSHConnection:
         return SSHConnection(ssh_config=ssh_config,
-                             remote_module="/run/jobadder-worker.socket",
+                             remote_module="/tmp/jobadder-worker.socket",
                              command_string="ja-remote %s")

--- a/src/ja/worker/main.py
+++ b/src/ja/worker/main.py
@@ -32,6 +32,7 @@ class JobWorker:
         @param remote_module: the module to execute on the server.
         @param command_string: the command template to execute on the server.
         """
+        logger.info("Using worker config file %s." % config_path)
         self._config_path = config_path
         with open(self._config_path, "r") as f:
             self._config = cast(WorkerConfig, WorkerConfig.from_string(f.read()))

--- a/src/ja/worker/main.py
+++ b/src/ja/worker/main.py
@@ -21,7 +21,7 @@ class JobWorker:
     """
     def __init__(
             self, config_path: str = "/etc/jobadder/worker.conf",
-            socket_path: str = "/run/jobadder-worker.socket",
+            socket_path: str = "/tmp/jobadder-worker.socket",
             remote_module: str = "ja.server.proxy.remote",
             command_string: str = "python3 -m %s") -> None:
         """!

--- a/src/ja/worker/main.py
+++ b/src/ja/worker/main.py
@@ -11,6 +11,7 @@ from ja.worker.docker import DockerInterface
 from ja.worker.proxy.command_handler import WorkerCommandHandler
 
 import time
+import sys
 import logging
 logger = logging.getLogger(__name__)
 
@@ -53,7 +54,7 @@ class JobWorker:
         if not register_response.is_success:
             logger.error("Failed to register with the server at %s: %s" %
                          (self._config.ssh_config.hostname, register_response.result_string))
-            return
+            sys.exit(1)
 
         # If uid is unset for this worker, save the uid assigned by the server for consistency.
         if self._config.uid is None:

--- a/src/ja/worker/proxy/command_handler.py
+++ b/src/ja/worker/proxy/command_handler.py
@@ -23,7 +23,7 @@ class WorkerCommandHandler(CommandHandler):
     """
     def __init__(self,
                  admin_group: str, docker_interface: DockerInterface,
-                 socket_path: str = "/run/jobadder-worker.socket"):
+                 socket_path: str = "/tmp/jobadder-worker.socket"):
         super().__init__(socket_path=socket_path, admin_group=admin_group)
         self._docker_interface = docker_interface
 

--- a/src/test/integration/base.py
+++ b/src/test/integration/base.py
@@ -47,12 +47,6 @@ class TestWorkerProxyFactory(WorkerProxyFactoryBase):
 
 
 class TestJobCenter(JobCenter):
-
-    @staticmethod
-    def _read_config() -> ServerConfig:
-        with open(SERVER_CONF_PATH) as f:
-            return ServerConfig.from_string(f.read())
-
     def _get_proxy_factory(self) -> WorkerProxyFactoryBase:
         return TestWorkerProxyFactory(self._database)
 
@@ -71,7 +65,8 @@ class IntegrationTest(TestCase):
         Path(TESTING_DIRECTORY).mkdir(parents=True, exist_ok=True)
         with open(SERVER_CONF_PATH, "w") as f:
             f.write(str(self.server_config))
-        self._server = TestJobCenter(socket_path=SERVER_SOCKET_PATH, database_name=DATABASE_NAME)
+        self._server = TestJobCenter(config_file=SERVER_CONF_PATH,
+                                     socket_path=SERVER_SOCKET_PATH, database_name=DATABASE_NAME)
         Thread(target=self._server.run, name="server-main", daemon=True).start()
 
         with open(SSH_CONF_PATH, "w") as f:


### PR DESCRIPTION
This PR makes it possible to run job adder server/worker without root access.
Based on #143

TODO:

- [x] ~~Create special user at startup and~~ run the systemd units as this user, I think the administrator should set up the account themselves since they should also set a password, ssh keys, etc.
