### PR TITLE
removed error logs from database

### DIFF
--- a/src/ja/server/database/sql/database.py
+++ b/src/ja/server/database/sql/database.py
@@ -194,7 +194,7 @@ class SQLDatabase(ServerDatabase):
             logger.info("job entry with job id: %s found." % job_id)
             logger.debug(str(jobs_entry.job))
         else:
-            logger.error("job with id: %s not found" % job_id)
+            logger.info("job with id: %s not found" % job_id)
         return jobs_entry
 
     def find_job_by_label(self, label: str) -> List[Job]:


### PR DESCRIPTION
Most tests cause the logger to log errors because some methods check if a job with a given uid exists in the database or not, so there's always an error when a new job is added because it's not in the database yet.