### PR TITLE
Installation guide, misc adjustments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: python
 python: 3.7
 install: "pip3 install flake8 mypy==0.761 PyYAML psycopg2 SQLAlchemy testing.postgresql sqlalchemy-stubs paramiko freezegun docker"
 script:
-  - sudo groupadd jobadder
+  - sudo useradd --system jobadder
+  - sudo usermod -a -G docker jobadder
   - sudo usermod -a -G jobadder travis
   - ssh-keygen -f ~/.ssh/id_rsa -P "" -t rsa -m PEM
   - cp ~/.ssh/id_rsa.pub ~/.ssh/authorized_keys

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,91 @@
+This file gives a detailed explanation of how to install JobAdder on user clients, the server, or worker clients.
+Note that all components of JobAdder were designed to be used exclusively on Linux.
+Furthermore, the server and the worker clients are assumed to be using central authentication (e.g. LDAP).
+
+## Requirements
+The following software is required to run JobAdder:
+
+- Python, 3.7 or higher (user client, server, and worker clients)
+- PostgreSQL (server)
+- Docker, recent version (worker clients)
+
+## Installation Notes (Linux)
+Detailed step-by-step instructions to install JobAdder.
+
+### 1. Install JobAdder
+The git repository can be cloned by running:
+    
+    git clone https://github.com/DistributedTaskScheduling/JobAdder
+
+After that, execute the *install.sh* script located in the git repository's root directory with superuser privileges.
+This will install JobAdder system-wide through pip.
+
+### 2. Post-Installation Instructions
+Additional steps to take after the installation of JobAdder.
+#### 2.1 Post-Installation Instructions (Server)
+Additional steps to take on the server.
+##### 2.1.1 Create the jobadder User and Group
+Add the *jobadder* user and the corresponding group by running:
+
+    sudo useradd --system jobadder
+
+The jobadder user is used by the daemons running on the server and the worker clients.
+Users in the jobadder group are granted administrative privileges in the context of JobAdder: 
+they can manage worker clients and the jobs of any user.
+
+The jobadder user needs to be added to the docker group to run jobs:
+
+    sudo usermod -a -G docker jobadder
+
+##### 2.1.2 Configure PostgreSQL
+Create a PostgreSQL user called *jobadder*:
+
+    sudo -u postgres createuser --pwprompt jobadder
+
+Create a PostgreSQL database called *jobadder*:
+
+    sudo -u postgres createdb --owner=jobadder jobadder
+
+Make sure to configure the [authentication method](https://www.postgresql.org/docs/12/auth-methods.html) of your PostgreSQL installation.
+JobAdder was designed to use password authentication.
+##### 2.1.3 Enable the systemd Service
+To automatically start the JobAdder server on boot run:
+
+    sudo systemctl enable JobAdderServer.service
+
+##### 2.1.4 Modify the Configuration File
+The default values in the configuration file located under */etc/jobadder/server.conf* need to be adjusted:
+
+- Set *database_config/password* to the password you set for the PostgreSQL jobadder user.
+- Set the values of *email_config* to the login data of an SMTP server if you want to use email notifications.
+- Set *special_resources* available amounts for special resources (e.g. software licenses) that jobs might need to run.
+- Set a port for the web server if you want to use it.
+
+#### 2.1 Post-Installation Instructions (Worker Client)
+Additional steps to take on worker clients.
+##### 2.1.1 Enable the systemd Service
+To automatically start the JobAdder worker client on boot run:
+
+    sudo systemctl enable JobAdderWorker.service
+
+##### 2.1.2 Modify the Configuration File
+The default values in the configuration file located under */etc/jobadder/worker.conf* need to be adjusted:
+
+- Set *ssh_config/hostname* to the IP address of the server.
+- Set the values under *resource_allocation* to the values made available to workers. The values for memory and swap space are interpreted as megabytes.
+- Optional: set *uid* to a human-readable name that identifies this worker. If *uid* is not set, the server will assign it.
+
+#### 2.1 Post-Installation Instructions (User Client)
+Additional steps to take on user clients.
+##### 2.1.1 Set Up SSH Config (Optional)
+Very often the CLI arguments used to connect to the server is the same across multiple jobs.
+The defaults for these arguments can be changed by creating a configuration file under *~/.config/jobadder*.
+The configuration file must be in the YAML format (<arg_name>: <arg_value>) and can provide a default for the following CLI arguments:
+
+- verbosity
+- hostname
+- username
+- password
+- key_path
+- passphrase
+- email

--- a/data/config-files/server.conf
+++ b/data/config-files/server.conf
@@ -1,14 +1,14 @@
 admin_group: jobadder
 database_config:
         host: 127.0.0.1
-        port: 1
-        username: postgres
-        password: test123
+        port: 5432
+        username: jobadder
+        password: jobadder
 email_config:
         host: 127.0.0.1
         port: 1
-        username: ammen99
-        password: ammen99
+        username: jobadder
+        password: jobadder
 special_resources:
         test: 10
 blocking_enabled: True

--- a/data/config-files/worker.conf
+++ b/data/config-files/worker.conf
@@ -6,5 +6,5 @@ resource_allocation:
         cpu_threads: 1
         memory: 1
         swap: 1
-uid: worker0
+uid:
 admin_group: jobadder

--- a/install.sh
+++ b/install.sh
@@ -45,9 +45,9 @@ WORKER_CONFIG_FILE=/etc/jobadder/worker.conf
 
 if [ ! -f $SERVER_CONFIG_FILE ]; then
     mkdir -p /etc/jobadder/
-    install ./data/config-files/server.conf $SERVER_CONFIG_FILE -m 644
+    install ./data/config-files/server.conf $SERVER_CONFIG_FILE -m 600
 fi
 
 if [ ! -f $WORKER_CONFIG_FILE ]; then
-    install ./data/config-files/worker.conf $WORKER_CONFIG_FILE -m 644
+    install ./data/config-files/worker.conf $WORKER_CONFIG_FILE -m 600
 fi

--- a/src/ja/server/database/sql/database.py
+++ b/src/ja/server/database/sql/database.py
@@ -26,11 +26,14 @@ class SQLDatabase(ServerDatabase):
     """
     _metadata: MetaData = None
 
-    def __init__(self, host: str = None, user: str = None, password: str = None, database_name: str = "jobadder"):
+    def __init__(
+            self, host: str = None, port: int = 5432, user: str = None, password: str = None,
+            database_name: str = "jobadder"):
         """!
         Create the SQLDatabase object and connect to the given database.
 
         @param host The host of the database to connect to.
+        @param port The port on which to connect to the database.
         @param user The username to use for the connection.
         @param password The password to use for the connection.
         @param database_name The name of the database to use.
@@ -169,7 +172,10 @@ class SQLDatabase(ServerDatabase):
             })
         if user is not None and password is not None and host is not None:
             # example: "postgresql://pesho:pesho@127.0.0.1:5432/jobadd"
-            _conn: str = "postgresql://" + user + ":" + password + "@" + host + "/" + database_name
+            if port is None:
+                _conn = "postgresql://%s:%s@%s/%s" % (user, password, host, database_name)
+            else:
+                _conn = "postgresql://%s:%s@%s:%s/%s" % (user, password, host, port, database_name)
             self.engine = create_engine(_conn)
             self.scoped = scoped_session(sessionmaker(self.engine))
             SQLDatabase._metadata.create_all(self.engine)

--- a/src/ja/server/main.py
+++ b/src/ja/server/main.py
@@ -65,6 +65,7 @@ class JobCenter:
 
         config = self._read_config(config_file)
         self._database = SQLDatabase(host=config.database_config.host,
+                                     port=config.database_config.port,
                                      user=config.database_config.username,
                                      password=config.database_config.password,
                                      database_name=database_name)


### PR DESCRIPTION
Fixes https://github.com/DistributedTaskScheduling/JobAdder/issues/166 .

This PR adds an installation guide.
It also does a few related changes:

* Fixed server config database port not actually being used.
* Passwords no longer mandatory properties for login configs.
* Create jobadder system account in travis script.
* Add jobadder user to the docker group in travis script.
* Removed read permissions for server/worker configuration files because they contain passwords.