### PR TITLE
main: reset scheduler callback when doing cleanup

### DIFF
--- a/src/ja/server/database/sql/database.py
+++ b/src/ja/server/database/sql/database.py
@@ -35,7 +35,7 @@ class SQLDatabase(ServerDatabase):
         @param password The password to use for the connection.
         @param database_name The name of the database to use.
         """
-        self.scheduler_callback: Callable[["ServerDatabase"], None] = lambda *args: None
+        self.scheduler_callback: Callable[["ServerDatabase"], None] = None
         self.status_callback: Callable[["Job"], None] = lambda *args: None
         self.in_scheduler_callback: bool = False
         self.in_atomic_update: bool = False
@@ -324,7 +324,7 @@ class SQLDatabase(ServerDatabase):
         return deepcopy([job for job in jobs if job.statistics.time_added >= since])
 
     def _call_scheduler(self) -> None:
-        if not self.in_scheduler_callback and not self.in_atomic_update:
+        if not self.in_scheduler_callback and not self.in_atomic_update and self.scheduler_callback:
             self.in_scheduler_callback = True
             logger.info("calling scheduler callback")
             self.scheduler_callback(self)

--- a/src/ja/server/main.py
+++ b/src/ja/server/main.py
@@ -43,6 +43,7 @@ class JobCenter:
             if job.job.status in [JobStatus.RUNNING, JobStatus.PAUSED]:
                 job.job.status = JobStatus.CRASHED
                 self._database.update_job(job.job)
+                self._database.assign_job_machine(job.job, None)
 
         for machine in self._database.get_work_machines():
             machine.resources.deallocate(machine.resources.total_resources - machine.resources.free_resources)
@@ -94,4 +95,6 @@ class JobCenter:
         """
         logger.info("starting main loop")
         self._handler.main_loop()
+        # Cleanup, but don't invoke scheduler anymore.
+        self._database.set_scheduler_callback(None)
         self._cleanup()


### PR DESCRIPTION
Otherwise, we may try to schedule more jobs as resources are freed.

I just noticed this, even though I don't have a test to reproduce.