### PR TITLE
Add support for cancelling jobs in the scheduler

### DIFF
--- a/src/ja/server/scheduler/scheduler.py
+++ b/src/ja/server/scheduler/scheduler.py
@@ -1,10 +1,10 @@
 from copy import deepcopy
 from ja.common.job import JobStatus
 from ja.server.database.database import ServerDatabase
-from ja.server.database.types.work_machine import WorkMachineState
+from ja.server.database.types.work_machine import WorkMachineState, WorkMachine
 from ja.server.dispatcher.dispatcher import Dispatcher
 from ja.server.scheduler.algorithm import SchedulingAlgorithm, get_allocation_for_job
-from typing import Dict
+from typing import Dict, List
 
 
 class Scheduler:
@@ -43,6 +43,29 @@ class Scheduler:
         """
         return self._total_special_resources
 
+    def _update_special_resources(self, actual_distribution: ServerDatabase.JobDistribution) -> None:
+        self._special_resources = deepcopy(self._total_special_resources)
+        for job in actual_distribution:
+            if job.job.status in [JobStatus.RUNNING, JobStatus.PAUSED]:
+                for resource in job.job.scheduling_constraints.special_resources:
+                    assert resource in self._special_resources
+                    self._special_resources[resource] -= 1
+
+    def _recalculate_machine_resources(self, actual_distribution: ServerDatabase.JobDistribution,
+                                       machines: List[WorkMachine]) -> None:
+        # Reset resources and recalculate them
+        for machine in machines:
+            machine.resources.deallocate(machine.resources.total_resources - machine.resources.free_resources)
+
+        # Note we don't get done/crashed for cancelled jobs, so we should mark them as freed here
+        for job in actual_distribution:
+            if not job.assigned_machine:
+                assert job.job.status == JobStatus.QUEUED
+                continue
+
+            machine = next(m for m in machines if m.uid == job.assigned_machine.uid)
+            machine.resources.allocate(get_allocation_for_job(job.job))
+
     def reschedule(self, database: ServerDatabase) -> None:
         """!
         Fetches the current schedule from the database and redistributes the jobs using the scheduling algorithm.
@@ -51,29 +74,26 @@ class Scheduler:
         @param database The database to fetch job schedule from.
         """
         available_machines = list(filter(lambda m: m.state == WorkMachineState.ONLINE, database.get_work_machines()))
-        new_schedule = self._algorithm.reschedule_jobs(database.get_current_schedule(),
-                                                       available_machines, self.special_resources)
 
-        # Reset resources and recalculate them
-        for machine in available_machines:
-            machine.resources.deallocate(machine.resources.total_resources - machine.resources.free_resources)
-        self._special_resources = deepcopy(self._total_special_resources)
+        current_schedule = database.get_current_schedule()
+        cancelled_entries = [je for je in current_schedule if je.job.status == JobStatus.CANCELLED]
+        runnable_entries = [je for je in current_schedule if je.job.status in
+                            [JobStatus.QUEUED, JobStatus.RUNNING, JobStatus.PAUSED]]
 
+        self._update_special_resources(runnable_entries)
+        self._recalculate_machine_resources(runnable_entries, available_machines)
+        new_schedule = self._algorithm.reschedule_jobs(runnable_entries, available_machines, self.special_resources)
+
+        self._recalculate_machine_resources(new_schedule, available_machines)
         for job in new_schedule:
-            if not job.assigned_machine:
-                assert job.job.status == JobStatus.QUEUED
-                continue
-
-            database.update_job(job.job)
-            database.assign_job_machine(job.job, job.assigned_machine)
-
-            machine = next(m for m in available_machines if m.uid == job.assigned_machine.uid)
-            machine.resources.allocate(get_allocation_for_job(job.job))
-            for resource in job.job.scheduling_constraints.special_resources:
-                assert resource in self._special_resources
-                self._special_resources[resource] -= 1
+            if job.assigned_machine:
+                database.update_job(job.job)
+                database.assign_job_machine(job.job, job.assigned_machine)
 
         for machine in available_machines:
             database.update_work_machine(machine)
 
-        self._dispatcher.set_distribution(new_schedule)
+        self._update_special_resources(new_schedule)
+        self._dispatcher.set_distribution(new_schedule + cancelled_entries)
+        for job in cancelled_entries:
+            database.assign_job_machine(job.job, None)

--- a/src/test/integration/test_cancel.py
+++ b/src/test/integration/test_cancel.py
@@ -1,0 +1,48 @@
+from ja.common.job import JobStatus
+from ja.common.work_machine import ResourceAllocation
+from test.integration.base import IntegrationTest
+from time import sleep
+from typing import Any, List, Tuple
+
+
+class TestJobCancel(IntegrationTest):
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.list_updates: List[Tuple[str, JobStatus]] = []
+
+    def test_cancel(self) -> None:
+        """
+        Run one job, queue another and cancel both.
+        """
+        self._clients[0].run(
+            self.get_arg_list_add(num_seconds=5, label="lo", priority="0", threads=4, memory=16 * 1024))
+        self._clients[1].run(
+            self.get_arg_list_add(num_seconds=1, label="me", priority="1", threads=4, memory=16 * 1024))
+        sleep(1)  # Wait for first job to get scheduled
+        self._clients[2].run(["cancel", "-l", "me"])
+        jobs = self._server._database.query_jobs(None, -1, None)
+        db_lo = [job for job in jobs if job.job.label == "lo"][0]
+        db_me = [job for job in jobs if job.job.label == "me"][0]
+        db_wm = self._server._database.get_all_work_machines()[0]
+        self.assertEqual(db_lo.job.status, JobStatus.RUNNING)
+        self.assertEqual(db_me.job.status, JobStatus.CANCELLED)
+        self.assertEqual(db_wm.resources.free_resources, ResourceAllocation(0, 0, 16 * 1024))
+        self.assertEqual(len(self._workers[0]._docker_interface._jobs_by_container_id), 1)
+        self._clients[3].run(["cancel", "-l", "lo"])
+
+        jobs = self._server._database.query_jobs(None, -1, None)
+        db_lo = [job for job in jobs if job.job.label == "lo"][0]
+        db_me = [job for job in jobs if job.job.label == "me"][0]
+        db_wm = self._server._database.get_all_work_machines()[0]
+        self.assertEqual(db_lo.job.status, JobStatus.CANCELLED)
+        self.assertEqual(db_me.job.status, JobStatus.CANCELLED)
+        self.assertEqual(db_wm.resources.free_resources, ResourceAllocation(4, 16 * 1024, 16 * 1024))
+        self.assertEqual(len(self._workers[0]._docker_interface._jobs_by_container_id), 0)
+
+    @property
+    def num_workers(self) -> int:
+        return 1
+
+    @property
+    def num_clients(self) -> int:
+        return 4


### PR DESCRIPTION
Since the jobs are still running, they need to come to the scheduler which then dispatches the cancel command to the workers.

The resources of these jobs need to be deallocated by the scheduler.

Fixes #165