### PR TITLE
Web api test

### DIFF
--- a/src/ja/server/main.py
+++ b/src/ja/server/main.py
@@ -82,6 +82,8 @@ class JobCenter:
 
         if config.web_server_port > 0:
             self._web_server = StatisticsWebServer("", config.web_server_port, self._database)
+        else:
+            self._web_server = None
 
         self._database.set_scheduler_callback(self._scheduler.reschedule)
         self._database.set_job_status_callback(self._email.handle_job_status_updated)
@@ -99,3 +101,5 @@ class JobCenter:
         # Cleanup, but don't invoke scheduler anymore.
         self._database.set_scheduler_callback(None)
         self._cleanup()
+        if self._web_server:
+            self._web_server.stop()

--- a/src/ja/server/web/api_server.py
+++ b/src/ja/server/web/api_server.py
@@ -5,6 +5,9 @@ from typing import List, Any
 import ja.server.web.requests as req
 import threading
 
+import logging
+logger = logging.getLogger(__name__)
+
 
 def WebRequestHandlerFactory(database: ServerDatabase, mock_only: bool = False) -> type:
     class WebRequestHandler(BaseHTTPRequestHandler):
@@ -95,8 +98,8 @@ class StatisticsWebServer:
                 self._server.handle_request()
             self._server.server_close()
         except Exception as e:
-            print("Failed to start WebAPI server.")
-            print(e)
+            logger.error("Failed to start WebAPI server.")
+            logger.error(e)
 
     def __init__(self, server_name: str, server_port: int, database: ServerDatabase):
         """!
@@ -108,9 +111,13 @@ class StatisticsWebServer:
         """
         self._quit = False
         self._thread = threading.Thread(target=self._server_thread, args=(server_name, server_port, database))
+        self._thread.setDaemon(True)
         self._thread.start()
 
-    def __del__(self) -> None:
+    def stop(self) -> None:
+        """
+        Stop the web server.
+        """
         if self._thread.is_alive():
             self._quit = True
             self._thread.join()

--- a/src/ja/server/web/api_server.py
+++ b/src/ja/server/web/api_server.py
@@ -6,7 +6,7 @@ import ja.server.web.requests as req
 import threading
 
 
-def WebRequestHandlerFactory(database: ServerDatabase, mock_only: bool = True) -> type:
+def WebRequestHandlerFactory(database: ServerDatabase, mock_only: bool = False) -> type:
     class WebRequestHandler(BaseHTTPRequestHandler):
         """!
         Handle a request to generate statistics.

--- a/src/test/integration/test_web_api.py
+++ b/src/test/integration/test_web_api.py
@@ -1,0 +1,56 @@
+from ja.server.config import ServerConfig
+from test.integration.base import IntegrationTest
+from typing import Any, Dict, cast
+
+import requests
+import yaml
+
+
+class TestWebAPI(IntegrationTest):
+    def run_query(self, url: str, expect_code: int, expect_content: Dict[str, Any] = {}) -> None:
+        query = requests.get("http://127.0.0.1:12345/" + url)
+        self.assertEqual(query.status_code, expect_code)
+        if expect_code == 200:
+            response = cast(Dict[str, object], yaml.load(query.content, Loader=yaml.SafeLoader))
+            self.assertDictEqual(response, expect_content)
+
+    def test_web_api(self) -> None:
+        """
+        A test where a worker and 2 jobs are added, then basic checks are made via the WebAPI.
+        """
+        self._clients[0].run(
+            self.get_arg_list_add(num_seconds=5, label="lo", priority="0", threads=4, memory=16 * 1024))
+        self._clients[1].run(
+            self.get_arg_list_add(num_seconds=5, label="me", priority="1", threads=4, memory=16 * 1024))
+
+        self.run_query("v1/invalid", 404)
+
+        jobs = self._server._database.query_jobs(None, -1, None)
+        machine = self._server._database.get_work_machines()[0]
+
+        jobs_uid_dict = {"jobs": [{"job_id": job.job.uid} for job in jobs]}
+        self.run_query("v1/user/root/jobs", 200, jobs_uid_dict)
+
+        workload = {
+            "machines": [{
+                "id": machine.uid,
+                "cpu_load": {"used": 4, "free": 0},
+                "memory_load": {"used": 16 * 1024, "free": 0},
+                "swap_space": {"used": 0, "free": 16 * 1024},
+            }]
+        }
+        self.run_query("v1/workmachines/workload", 200, workload)
+
+    @property
+    def server_config(self) -> ServerConfig:
+        cfg = super().server_config
+        cfg._web_server_port = 12345
+        return cfg
+
+    @property
+    def num_workers(self) -> int:
+        return 1
+
+    @property
+    def num_clients(self) -> int:
+        return 2

--- a/src/test/server/web/test_api_server.py
+++ b/src/test/server/web/test_api_server.py
@@ -102,4 +102,4 @@ class StatisticsWebServerTest(TestCase):
         sock.close()
 
         # Clean up
-        server.__del__()
+        server.stop()


### PR DESCRIPTION
Fixes #182 and several bugs I encountered along the way:

1. web server thread is now marked as daemon so that it exits in the integration test
2. Seems like in this case the `__del__` of the WebApi is not called, thus I replaced it with manual shutdown called at the end
3. `mock_only` was defaulting to True, now it is False. Took me quite a long time :(
4. I don't test all web requests, because there are unit tests for them. I just wanted to test whether we correctly handle a) bad urls b) correct requests