### PR TITLE
Email logging improvements & Crash fix

### DIFF
--- a/src/ja/common/job.py
+++ b/src/ja/common/job.py
@@ -212,7 +212,7 @@ class Job(Serializable):
         NEW -> QUEUED
         QUEUED -> CANCELLED | RUNNING
         RUNNING -> PAUSED | DONE | CANCELLED | CRASHED
-        PAUSED -> CANCELLED | RUNNING
+        PAUSED -> CANCELLED | RUNNING | DONE | CRASHED
 
         If the transition requested is not allowed, or if the job has not
         been assigned an UID, a RuntimeError will be raised.
@@ -226,7 +226,7 @@ class Job(Serializable):
         elif self._status == JobStatus.RUNNING:
             transition_legal = new_status in [JobStatus.PAUSED, JobStatus.DONE, JobStatus.CANCELLED, JobStatus.CRASHED]
         elif self._status == JobStatus.PAUSED:
-            transition_legal = new_status in [JobStatus.CANCELLED, JobStatus.RUNNING]
+            transition_legal = new_status in [JobStatus.CANCELLED, JobStatus.RUNNING, JobStatus.DONE, JobStatus.CRASHED]
         else:
             transition_legal = False
         if transition_legal:

--- a/src/ja/server/email_notifier.py
+++ b/src/ja/server/email_notifier.py
@@ -7,6 +7,9 @@ from typing import Dict
 
 import ssl
 
+import logging
+logger = logging.getLogger(__name__)
+
 
 class EmailServerBase(ABC):
     """
@@ -43,10 +46,9 @@ class BasicEmailServer(EmailServerBase):
             self._email_client.ehlo()
             self._email_client.login(smtp_user, smtp_password)
         except (SMTPConnectError, ConnectionRefusedError) as e:
-            print("Failed connecting to SMTP server at %s:%d. No email notifications will be sent" %
-                  (smtp_server_address, smtp_server_port))
-            print("Reason for the failure:")
-            print(e)
+            logger.error("Failed connecting to SMTP server at %s:%d. No email notifications will be sent" %
+                         (smtp_server_address, smtp_server_port))
+            logger.error("Reason for the failure:\n%s" % str(e))
 
     def __del__(self) -> None:
         if self._email_client:
@@ -93,6 +95,7 @@ class EmailNotifier:
         if job.status not in self._send_email_for or not job.email:
             return
 
+        logger.info("Sending email for job %s(%s) to %s" % (job.uid, job.label, job.status))
         msg = self._EMAIL_TEMPLATE % (job.uid, self._send_email_for[job.status])
         subject = "JobAdder " + job.uid
         self._email_server.send_email(subject, msg, job.email)


### PR DESCRIPTION
Instead of print() we should use logging.

Also, I noticed that there is a race condition: If at the moment we pause a job, a message comes which makes it crashed or done: The message will be queued on the socket, we update the database with paused state, then we send the command to the worker which does nothing since the job has crashed. However, after that, the server processes the Done/Crashed message and tries to change the job status from PAUSED to DONE/CANCELLED, which up to now would have crashed the server.

As a result, I we should allow this kind of transition.