### PR TITLE
Fixed missing special resources crashing the server

### DIFF
--- a/src/ja/server/database/database.py
+++ b/src/ja/server/database/database.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import List, Callable
+from typing import List, Callable, Dict
 from ja.common.job import Job
 from ja.server.database.types.job_entry import DatabaseJobEntry
 from ja.server.database.types.work_machine import WorkMachine
@@ -122,3 +122,8 @@ class ServerDatabase(ABC):
         Marks the end of a series of atomic updates to the database.
         At this point, the scheduler will be called, even if no actual updates have been made.
         """
+
+    @property
+    @abstractmethod
+    def max_special_resources(self) -> Dict[str, int]:
+        """Maximum available special resources on the server."""

--- a/src/ja/server/database/sql/database.py
+++ b/src/ja/server/database/sql/database.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import List, Optional, Callable
+from typing import List, Optional, Callable, Dict
 from datetime import datetime
 import time
 from sqlalchemy import create_engine
@@ -28,7 +28,7 @@ class SQLDatabase(ServerDatabase):
 
     def __init__(
             self, host: str = None, port: int = 5432, user: str = None, password: str = None,
-            database_name: str = "jobadder"):
+            database_name: str = "jobadder", max_special_resources: Dict[str, int] = None):
         """!
         Create the SQLDatabase object and connect to the given database.
 
@@ -37,7 +37,9 @@ class SQLDatabase(ServerDatabase):
         @param user The username to use for the connection.
         @param password The password to use for the connection.
         @param database_name The name of the database to use.
+        @param max_special_resources Maximum available special resources on the server.
         """
+        self._max_special_resources = deepcopy(max_special_resources)
         self.scheduler_callback: Callable[["ServerDatabase"], None] = None
         self.status_callback: Callable[["Job"], None] = lambda *args: None
         self.in_scheduler_callback: bool = False
@@ -349,3 +351,7 @@ class SQLDatabase(ServerDatabase):
     def end_atomic_update(self) -> None:
         self.in_atomic_update = False
         self._call_scheduler()
+
+    @property
+    def max_special_resources(self) -> Dict[str, int]:
+        return deepcopy(self._max_special_resources)

--- a/src/ja/server/database/sql/mock_database.py
+++ b/src/ja/server/database/sql/mock_database.py
@@ -3,6 +3,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, scoped_session
 from ja.server.database.sql.database import SQLDatabase
 import logging
+from typing import Dict
 
 Postgresql = testing.postgresql.PostgresqlFactory(cache_initialized_db=True)
 
@@ -11,8 +12,8 @@ logger = logging.getLogger(__name__)
 
 class MockDatabase(SQLDatabase):
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, max_special_resources: Dict[str, int] = None) -> None:
+        super().__init__(max_special_resources=max_special_resources)
         self.postgresql = Postgresql()
         # connect to PostgreSQL
         self.engine = create_engine(self.postgresql.url())

--- a/src/ja/server/main.py
+++ b/src/ja/server/main.py
@@ -69,7 +69,8 @@ class JobCenter:
                                      port=config.database_config.port,
                                      user=config.database_config.username,
                                      password=config.database_config.password,
-                                     database_name=database_name)
+                                     database_name=database_name,
+                                     max_special_resources=config.special_resources)
         self._cleanup()
         proxy_factory = self._get_proxy_factory()
         self._dispatcher = Dispatcher(proxy_factory)

--- a/src/test/integration/base.py
+++ b/src/test/integration/base.py
@@ -119,7 +119,8 @@ class IntegrationTest(TestCase):
         email_config = LoginConfig(host="127.0.0.1", port=1337, username="", password="")
         return ServerConfig(
             admin_group="jobadder", database_config=database_config, email_config=email_config,
-            special_resources=dict(), blocking_enabled=True, preemption_enabled=True, web_server_port=0
+            special_resources=dict(SRA=1, SRB=3, SRC=1), blocking_enabled=True, preemption_enabled=True,
+            web_server_port=0
         )
 
     def get_worker_config(self, index: int) -> WorkerConfig:
@@ -141,7 +142,7 @@ class IntegrationTest(TestCase):
 
     def get_arg_list_add(
             self, num_seconds: int = 1, threads: int = 1, memory: int = 1024,
-            label: str = None, priority: str = "1") -> List[str]:
+            label: str = None, priority: str = "1", special_resources: List[str] = None) -> List[str]:
         arg_list = [
             "--hostname", "127.0.0.1",
             "add",
@@ -152,4 +153,7 @@ class IntegrationTest(TestCase):
         ]
         if label is not None:
             arg_list += ["--label", label]
+        if special_resources is not None:
+            arg_list.append("--special-resources")
+            arg_list += special_resources
         return arg_list

--- a/src/test/user/cli.py
+++ b/src/test/user/cli.py
@@ -23,7 +23,7 @@ class CLITest(TestCase):
                                  "add -c test/user/add.yaml --owner 0".split()]
 
     def setUp(self) -> None:
-        self._db = MockDatabase()
+        self._db = MockDatabase(max_special_resources={"lic": 1, "lic1": 1})
         self._jobs: List[Job] = [Job(1, "anon@biz.org", JobSchedulingConstraints(JobPriority.HIGH, False, []),
                                      DockerContext("print(2 + 3)\n", [MountPoint("f", "l"), MountPoint("a", "r")]),
                                      DockerConstraints(8, 8), "lab", status=JobStatus.QUEUED),


### PR DESCRIPTION
Fixes https://github.com/DistributedTaskScheduling/JobAdder/issues/184.

AddCommand.execute now checks if a job can be executed at all.
If the requested special resources don't exist at all or in insufficient quantity the job is not added.