### PR TITLE
Fixed exclusion of test, ja_integration when installing

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,13 +11,8 @@ PREFIX=/usr
 SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
 # Install JobAdder source code + binaries
-# FIXME: how to make setup.py ignore test folder??
 cd $SCRIPTPATH
-mv ./src/test/__init__.py ./src/test/init
-mv ./src/ja_integration/__init__.py ./src/ja_integration/init
 pip3 install ./src --prefix=$PREFIX
-mv ./src/test/init ./src/test/__init__.py
-mv ./src/ja_integration/init ./src/ja_integration/__init__.py
 
 install ./data/bin/jobadder /usr/bin -m 755
 install ./data/bin/ja-server /usr/bin -m 755

--- a/src/setup.py
+++ b/src/setup.py
@@ -11,7 +11,7 @@ setup(
     author='Ilia Bozhinov, Johannes Gäßler, ',  # TODO add everyone else
     author_email='ammen99@gmail.com, johannesg@5d6.de, ',  # TODO add everyone else
     url='https://github.com/DistributedTaskScheduling/JobAdder',
-    packages=find_packages(exclude="test"),
+    packages=find_packages(exclude=["test", "test.*", "ja_integration", "ja_integration.*"]),
     package_data={},
     keywords=[],
     license='GPL3',


### PR DESCRIPTION
This PR configures setup.py to ignore the test and ja_integration packages when installing JobAdder.