### PR TITLE
Loosened integration test timings to account for low-power CPUs

### DIFF
--- a/src/test/integration/test_cancel.py
+++ b/src/test/integration/test_cancel.py
@@ -15,9 +15,9 @@ class TestJobCancel(IntegrationTest):
         Run one job, queue another and cancel both.
         """
         self._clients[0].run(
-            self.get_arg_list_add(num_seconds=5, label="lo", priority="0", threads=4, memory=16 * 1024))
+            self.get_arg_list_add(num_seconds=60, label="lo", priority="0", threads=4, memory=16 * 1024))
         self._clients[1].run(
-            self.get_arg_list_add(num_seconds=1, label="me", priority="1", threads=4, memory=16 * 1024))
+            self.get_arg_list_add(num_seconds=60, label="me", priority="1", threads=4, memory=16 * 1024))
         sleep(1)  # Wait for first job to get scheduled
         self._clients[2].run(["cancel", "-l", "me"])
         jobs = self._server._database.query_jobs(None, -1, None)

--- a/src/test/integration/test_scheduler.py
+++ b/src/test/integration/test_scheduler.py
@@ -25,7 +25,7 @@ class TestScheduler(IntegrationTest):
             self.get_arg_list_add(num_seconds=1, label="hi", priority="3", threads=4, memory=16 * 1024))
         self._server._database.set_job_status_callback(self._status_updated)
         self._add_worker(0)
-        sleep(8)
+        sleep(25)
         expect: List[Tuple[str, JobStatus]] = [
             ("hi", JobStatus.RUNNING),
             ("hi", JobStatus.DONE),
@@ -43,11 +43,11 @@ class TestScheduler(IntegrationTest):
         self._add_worker(0)
         self._add_worker(1)
         self._clients[0].run(
-            self.get_arg_list_add(num_seconds=5, label="lo", priority="0", threads=4, memory=16 * 1024))
+            self.get_arg_list_add(num_seconds=60, label="lo", priority="0", threads=4, memory=16 * 1024))
         self._clients[1].run(
-            self.get_arg_list_add(num_seconds=5, label="me", priority="1", threads=2, memory=8 * 1024))
+            self.get_arg_list_add(num_seconds=60, label="me", priority="1", threads=2, memory=8 * 1024))
         self._clients[2].run(
-            self.get_arg_list_add(num_seconds=5, label="hi", priority="3", threads=2, memory=8 * 1024))
+            self.get_arg_list_add(num_seconds=60, label="hi", priority="3", threads=2, memory=8 * 1024))
         sleep(1)
         # Jobs can't have finished so they are all in the schedule
         distribution = self._server._database.get_current_schedule()
@@ -88,17 +88,17 @@ class TestScheduler(IntegrationTest):
         self._server._database.set_job_status_callback(self._status_updated)
         # Occupy half the machine
         self._clients[0].run(
-            self.get_arg_list_add(num_seconds=6, label="lo", priority="0", threads=2, memory=8 * 1024))
+            self.get_arg_list_add(num_seconds=12, label="lo", priority="0", threads=2, memory=8 * 1024))
         # This one should reserve the machine since it is blocking
         self._clients[1].run(
-            self.get_arg_list_add(num_seconds=1, label="hi", priority="2", threads=4, memory=16 * 1024))
+            self.get_arg_list_add(num_seconds=2, label="hi", priority="2", threads=4, memory=16 * 1024))
         # Won't run anytime soon since machine is reserved
         self._clients[2].run(
-            self.get_arg_list_add(num_seconds=1, label="me", priority="1", threads=2, memory=8 * 1024))
+            self.get_arg_list_add(num_seconds=2, label="me", priority="1", threads=2, memory=8 * 1024))
         # Urgent jobs however should override blocking
         self._clients[3].run(
-            self.get_arg_list_add(num_seconds=1, label="ur", priority="3", threads=3, memory=8 * 1024))
-        sleep(10)
+            self.get_arg_list_add(num_seconds=2, label="ur", priority="3", threads=3, memory=8 * 1024))
+        sleep(20)
         expect: List[Tuple[str, JobStatus]] = [
             ("lo", JobStatus.RUNNING),
             ("lo", JobStatus.PAUSED),

--- a/src/test/integration/test_web_api.py
+++ b/src/test/integration/test_web_api.py
@@ -19,9 +19,9 @@ class TestWebAPI(IntegrationTest):
         A test where a worker and 2 jobs are added, then basic checks are made via the WebAPI.
         """
         self._clients[0].run(
-            self.get_arg_list_add(num_seconds=5, label="lo", priority="0", threads=4, memory=16 * 1024))
+            self.get_arg_list_add(num_seconds=60, label="lo", priority="0", threads=4, memory=16 * 1024))
         self._clients[1].run(
-            self.get_arg_list_add(num_seconds=5, label="me", priority="1", threads=4, memory=16 * 1024))
+            self.get_arg_list_add(num_seconds=60, label="me", priority="1", threads=4, memory=16 * 1024))
 
         self.run_query("v1/invalid", 404)
 


### PR DESCRIPTION
I installed JobAdder on a 1.2 GHz ARM SBC and found that several integration tests were failing.
This was due to the current timings being too tight for very slow systems.
This PR loosens those timings so that the integration tests succeed on slow system.
The looser timings extend the time required to complete the tests by 27 seconds.