### PR TITLE
Removed hard-coded pip prefix

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,12 +7,11 @@ if [[ $EUID -ne 0 ]]; then
    exit 1
 fi
 
-PREFIX=/usr
 SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
 # Install JobAdder source code + binaries
 cd $SCRIPTPATH
-pip3 install ./src --prefix=$PREFIX
+pip3 install ./src
 
 install ./data/bin/jobadder /usr/bin -m 755
 install ./data/bin/ja-server /usr/bin -m 755

--- a/src/test/integration/test_simple.py
+++ b/src/test/integration/test_simple.py
@@ -33,9 +33,9 @@ class SimpleIntegrationTest(IntegrationTest):
         label_a = "JobA"
         label_b = "JobB"
         label_c = "JobC"
-        client.run(self.get_arg_list_add(num_seconds=1, label=label_a, special_resources=["SRA", "SRB"]))
-        client.run(self.get_arg_list_add(num_seconds=1, label=label_b, special_resources=["SRB", "SRB"]))
-        client.run(self.get_arg_list_add(num_seconds=1, label=label_c, special_resources=["SRD"]))
+        client.run(self.get_arg_list_add(num_seconds=60, label=label_a, special_resources=["SRA", "SRB"]))
+        client.run(self.get_arg_list_add(num_seconds=60, label=label_b, special_resources=["SRB", "SRB"]))
+        client.run(self.get_arg_list_add(num_seconds=60, label=label_c, special_resources=["SRD"]))
 
         active_job_entries = self._server._database.get_current_schedule()
         labels = [aje.job.label for aje in active_job_entries]


### PR DESCRIPTION
Currently the install script uses /usr as the hard-coded pip prefix.
However, when I installed JobAdder with this prefix on my SBC my python installation (and pip3) was not able to find it afterwards.
The operating system in use was a derivative of Ubuntu 16.04.

This PR removes the hard-coded prefix for the pip installation and instead lets pip decide where to install JobAdder.
Since the script is executed as root this will still be a system-wide installation.