### PR TITLE
Fixed mis-configured remote strings

### DIFF
--- a/data/bin/ja-worker
+++ b/data/bin/ja-worker
@@ -12,10 +12,9 @@ class WorkerCLI(SimpleDaemonCLIInterface):
     def run_main(self, config_file: str) -> None:
         jw: JobWorker = None
         if config_file:
-            jw = JobWorker(config_path=config_file, remote_module="/tmp/jobadder-server.socket",
-                           command_string="ja-remote %s")
+            jw = JobWorker(config_path=config_file)
         else:
-            jw = JobWorker(remote_module="/tmp/jobadder-server.socket", command_string="ja-remote %s")
+            jw = JobWorker()
         jw.run()
 
 

--- a/src/ja/user/main.py
+++ b/src/ja/user/main.py
@@ -13,7 +13,7 @@ class JobAdder:
     The main class for the JobAdder user client.
     """
     def __init__(self, config_path: str = "%s/.config/jobadder" % Path.home(),
-                 remote_module: str = "ja.server.proxy.remote", command_string: str = "python3 -m %s") -> None:
+                 remote_module: str = "/tmp/jobadder-server.socket", command_string: str = "ja-remote %s") -> None:
         self._cli_handler = UserClientCLIHandler(config_path=config_path)
         self._remote_module = remote_module
         self._command_string = command_string

--- a/src/ja/user/proxy.py
+++ b/src/ja/user/proxy.py
@@ -58,8 +58,8 @@ class UserServerProxy(UserServerProxyBase):
     """
     Implementation for the proxy for the central server used on the user client.
     """
-    def __init__(self, ssh_config: SSHConfig, remote_module: str = "ja.server.proxy.remote",
-                 command_string: str = "python3 -m %s"):
+    def __init__(self, ssh_config: SSHConfig, remote_module: str = "/tmp/jobadder-server.socket",
+                 command_string: str = "ja-remote %s"):
         super().__init__(ssh_config=ssh_config)
         self._remote_module = remote_module
         self._command_string = command_string

--- a/src/ja/worker/main.py
+++ b/src/ja/worker/main.py
@@ -25,8 +25,8 @@ class JobWorker:
     def __init__(
             self, config_path: str = "/etc/jobadder/worker.conf",
             socket_path: str = "/tmp/jobadder-worker.socket",
-            remote_module: str = "ja.server.proxy.remote",
-            command_string: str = "python3 -m %s") -> None:
+            remote_module: str = "/tmp/jobadder-server.socket",
+            command_string: str = "ja-remote %s") -> None:
         """!
         Reads a WorkerConfig object from the disk.
         Creates WorkerServerProxy, DockerInterface, WorkerCommandHandler objects.

--- a/src/ja/worker/proxy/proxy.py
+++ b/src/ja/worker/proxy/proxy.py
@@ -68,8 +68,8 @@ class WorkerServerProxy(IWorkerServerProxy):
     """
 
     def __init__(
-            self, ssh_config: SSHConfig, remote_module: str = "ja.server.proxy.remote",
-            command_string: str = "python3 -m %s"):
+            self, ssh_config: SSHConfig, remote_module: str = "/tmp/jobadder-server.socket",
+            command_string: str = "ja-remote %s"):
         self._ssh_config = ssh_config
         self._remote_module = remote_module
         self._command_string = command_string


### PR DESCRIPTION
The strings determining remote modules seem to be mis-configured on master.
At some point we added a special ja_remote binary to ensure that the SUID bit works correctly.
However, the strings defining the remotes on other machines were not adjusted.