### PR TITLE
Fixed config file ownership

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,34 +2,28 @@ This file gives a detailed explanation of how to install JobAdder on user client
 Note that all components of JobAdder were designed to be used exclusively on Linux.
 Furthermore, the server and the worker clients are assumed to be using central authentication (e.g. LDAP).
 
-## Requirements
+## Installation Notes (Linux)
+Detailed step-by-step instructions to install JobAdder.
+
+### 1. Pre-installation
+Steps to take before installing JobAdder.
+#### 1.1 Software requirements
 The following software is required to run JobAdder:
 
 - Python, 3.7 or higher (user client, server, and worker clients)
 - PostgreSQL (server)
 - Docker, recent version (worker clients)
 
-## Installation Notes (Linux)
-Detailed step-by-step instructions to install JobAdder.
+In order to run the JobAdder test suite all of the above software needs to be installed.
 
-### 1. Install JobAdder
-The git repository can be cloned by running:
-    
-    git clone https://github.com/DistributedTaskScheduling/JobAdder
-
-After that, execute the *install.sh* script located in the git repository's root directory with superuser privileges.
-This will install JobAdder system-wide through pip.
-
-### 2. Post-Installation Instructions
-Additional steps to take after the installation of JobAdder.
-#### 2.1 Post-Installation Instructions (Server)
-Additional steps to take on the server.
-##### 2.1.1 Create the jobadder User and Group
+When using a very minimalistic Linux distribution it might be necessary to install [additional packages](https://cryptography.io/en/latest/installation/)
+for the installation of the cryptography Python package (an indirect dependency). 
+#### 1.2 JobAdder system account
+On the server and the worker client the jobadder user needs to be created.
 Add the *jobadder* user and the corresponding group by running:
 
     sudo useradd --system jobadder
 
-The jobadder user is used by the daemons running on the server and the worker clients.
 Users in the jobadder group are granted administrative privileges in the context of JobAdder: 
 they can manage worker clients and the jobs of any user.
 
@@ -37,7 +31,20 @@ The jobadder user needs to be added to the docker group to run jobs:
 
     sudo usermod -a -G docker jobadder
 
-##### 2.1.2 Configure PostgreSQL
+A user that intends to run JobAdder integration tests also needs to be a member of the docker group.
+### 2. Install JobAdder
+The git repository can be cloned by running:
+    
+    git clone https://github.com/DistributedTaskScheduling/JobAdder
+
+After that, execute the *install.sh* script located in the git repository's root directory with superuser privileges.
+This will install JobAdder system-wide through pip.
+
+### 3. Post-Installation Instructions
+Additional steps to take after the installation of JobAdder.
+#### 3.1 Post-Installation Instructions (Server)
+Additional steps to take on the server.
+##### 3.1.1 Configure PostgreSQL
 Create a PostgreSQL user called *jobadder*:
 
     sudo -u postgres createuser --pwprompt jobadder
@@ -48,12 +55,12 @@ Create a PostgreSQL database called *jobadder*:
 
 Make sure to configure the [authentication method](https://www.postgresql.org/docs/12/auth-methods.html) of your PostgreSQL installation.
 JobAdder was designed to use password authentication.
-##### 2.1.3 Enable the systemd Service
+##### 3.1.2 Enable the systemd Service
 To automatically start the JobAdder server on boot run:
 
     sudo systemctl enable JobAdderServer.service
 
-##### 2.1.4 Modify the Configuration File
+##### 3.1.3 Modify the Configuration File
 The default values in the configuration file located under */etc/jobadder/server.conf* need to be adjusted:
 
 - Set *database_config/password* to the password you set for the PostgreSQL jobadder user.
@@ -61,23 +68,25 @@ The default values in the configuration file located under */etc/jobadder/server
 - Set *special_resources* available amounts for special resources (e.g. software licenses) that jobs might need to run.
 - Set a port for the web server if you want to use it.
 
-#### 2.1 Post-Installation Instructions (Worker Client)
+The server configuration file is by default not readable by users because it may contain passwords.
+#### 3.2 Post-Installation Instructions (Worker Client)
 Additional steps to take on worker clients.
-##### 2.1.1 Enable the systemd Service
+##### 3.2.1 Enable the systemd Service
 To automatically start the JobAdder worker client on boot run:
 
     sudo systemctl enable JobAdderWorker.service
 
-##### 2.1.2 Modify the Configuration File
+##### 3.2.2 Modify the Configuration File
 The default values in the configuration file located under */etc/jobadder/worker.conf* need to be adjusted:
 
 - Set *ssh_config/hostname* to the IP address of the server.
 - Set the values under *resource_allocation* to the values made available to workers. The values for memory and swap space are interpreted as megabytes.
 - Optional: set *uid* to a human-readable name that identifies this worker. If *uid* is not set, the server will assign it.
 
-#### 2.1 Post-Installation Instructions (User Client)
+The worker configuration file is by default not readable by users because it may contain passwords.
+#### 3.3 Post-Installation Instructions (User Client)
 Additional steps to take on user clients.
-##### 2.1.1 Set Up SSH Config (Optional)
+##### 3.3.1 Set Up SSH Config (Optional)
 Very often the CLI arguments used to connect to the server is the same across multiple jobs.
 The defaults for these arguments can be changed by creating a configuration file under *~/.config/jobadder*.
 The configuration file must be in the YAML format (<arg_name>: <arg_value>) and can provide a default for the following CLI arguments:

--- a/install.sh
+++ b/install.sh
@@ -39,9 +39,9 @@ WORKER_CONFIG_FILE=/etc/jobadder/worker.conf
 
 if [ ! -f $SERVER_CONFIG_FILE ]; then
     mkdir -p /etc/jobadder/
-    install ./data/config-files/server.conf $SERVER_CONFIG_FILE -m 600
+    install ./data/config-files/server.conf $SERVER_CONFIG_FILE -m 600 -o jobadder -g jobadder
 fi
 
 if [ ! -f $WORKER_CONFIG_FILE ]; then
-    install ./data/config-files/worker.conf $WORKER_CONFIG_FILE -m 600
+    install ./data/config-files/worker.conf $WORKER_CONFIG_FILE -m 600 -o jobadder -g jobadder
 fi


### PR DESCRIPTION
On master the config files for server and worker are owned by root:root with 600 permissions.
However, since the server and worker daemons are executed as the user jobadder this means that the daemons don't have permission to read the config files.
This PR changes config file ownership to jobadder:jobadder with 600 permissions; the daemons can read and write config files but users in the jobadder group and regular users still do not have permission.
