### PR TITLE
improved query responses

### DIFF
--- a/src/ja/user/cli.py
+++ b/src/ja/user/cli.py
@@ -92,7 +92,8 @@ class UserClientCLIHandler:
 
         parser: ArgumentParser = ArgumentParser("JobAdder: add, cancel or a query a job.")
         # shared options
-        parser.add_argument("--verbosity", "-v", type=int, choices=[0, 1, 2], default=verbosity)
+        parser.add_argument("--verbosity", "-v", type=int, choices=[0, 1, 2], default=verbosity,
+                            help="The level of detail in the reponses.")
         parser.add_argument("--hostname", "--host", type=str,
                             required=hostname is None, default=hostname,
                             help="The name of the server to connect to.")
@@ -138,8 +139,8 @@ class UserClientCLIHandler:
                                   choices="false true t f".split(),
                                   help="Get job(s) that can be preempted by other jobs.")
         parser_query.add_argument("--special-resources", "--sr", help="Filter by the special resources of a job. \
-                                                                       Special resources are separated bx a comma \
-                                                                       and lists of speacial resources are separated \
+                                                                       Special resources are separated by a comma \
+                                                                       and lists of special resources are separated \
                                                                        by a point. \
                                                                        [sr,sr1,sr2,sr3].[...].[...]...")
         parser_query.add_argument("--threads", "-t",

--- a/src/test/integration/test_quering.py
+++ b/src/test/integration/test_quering.py
@@ -14,6 +14,7 @@ class QueryIntegrationTest(IntegrationTest):
     def _get_arg_list_query(self) -> List[str]:
         arg_list = [
             "--hostname", "127.0.0.1",
+            "-v", "2",
             "query",
             "--status", "done",
             "--label", "not_a_bitcoin_miner"

--- a/src/test/user/cli.py
+++ b/src/test/user/cli.py
@@ -61,63 +61,63 @@ class CLITest(TestCase):
         self.assertCountEqual([entry.job for entry in self._db.query_jobs(None, -1, None)], self._jobs)
 
     def test_query_threads(self) -> None:
-        command: QueryCommand = cast(QueryCommand, self._cli.get_server_command("query -t 6 8".split()))
+        command: QueryCommand = cast(QueryCommand, self._cli.get_server_command("-v 2 query -t 6 8".split()))
         response: str = self._proxy.query(command).result_string
         response1: str = command.execute(self._db).result_string
         self.assertEqual(response, "\n".join([str(self._jobs[0]), str(self._jobs[2])]))
         self.assertEqual(response1, "\n".join([str(self._jobs[0]), str(self._jobs[2])]))
 
     def test_query_owner(self) -> None:
-        command: QueryCommand = cast(QueryCommand, self._cli.get_server_command("query --owner 9".split()))
+        command: QueryCommand = cast(QueryCommand, self._cli.get_server_command("-v 2 query --owner 9".split()))
         response: str = self._proxy.query(command).result_string
         response1: str = command.execute(self._db).result_string
         self.assertEqual(response, "\n".join([str(self._jobs[1]), str(self._jobs[2]), str(self._jobs[3])]))
         self.assertEqual(response1, "\n".join([str(self._jobs[1]), str(self._jobs[2]), str(self._jobs[3])]))
 
     def test_query_label(self) -> None:
-        command: QueryCommand = cast(QueryCommand, self._cli.get_server_command("query --label lab".split()))
+        command: QueryCommand = cast(QueryCommand, self._cli.get_server_command("-v 2 query --label lab".split()))
         response: str = self._proxy.query(command).result_string
         response1: str = command.execute(self._db).result_string
         self.assertEqual(response, "\n".join([str(self._jobs[0]), str(self._jobs[1])]))
         self.assertEqual(response1, "\n".join([str(self._jobs[0]), str(self._jobs[1])]))
 
     def test_query_priority(self) -> None:
-        command: QueryCommand = cast(QueryCommand, self._cli.get_server_command("query -p low".split()))
+        command: QueryCommand = cast(QueryCommand, self._cli.get_server_command("-v 2 query -p low".split()))
         response: str = self._proxy.query(command).result_string
         response1: str = command.execute(self._db).result_string
         self.assertEqual(response, "\n".join([str(self._jobs[1]), str(self._jobs[2])]))
         self.assertEqual(response1, "\n".join([str(self._jobs[1]), str(self._jobs[2])]))
 
     def test_query_uid(self) -> None:
-        command: QueryCommand = cast(QueryCommand, self._cli.get_server_command("query --uid 1 3".split()))
+        command: QueryCommand = cast(QueryCommand, self._cli.get_server_command("-v 2 query --uid 1 3".split()))
         response: str = self._proxy.query(command).result_string
         response1: str = command.execute(self._db).result_string
         self.assertEqual(response, "\n".join([str(self._jobs[1]), str(self._jobs[3])]))
         self.assertEqual(response1, "\n".join([str(self._jobs[1]), str(self._jobs[3])]))
 
     def test_query_memory(self) -> None:
-        command: QueryCommand = cast(QueryCommand, self._cli.get_server_command("query --memory 1 4".split()))
+        command: QueryCommand = cast(QueryCommand, self._cli.get_server_command("-v 2 query --memory 1 4".split()))
         response: str = self._proxy.query(command).result_string
         response1: str = command.execute(self._db).result_string
         self.assertEqual(response, "\n".join([str(self._jobs[1]), str(self._jobs[2]), str(self._jobs[3])]))
         self.assertEqual(response1, "\n".join([str(self._jobs[1]), str(self._jobs[2]), str(self._jobs[3])]))
 
     def test_query_status(self) -> None:
-        command: QueryCommand = cast(QueryCommand, self._cli.get_server_command("query --status running".split()))
+        command: QueryCommand = cast(QueryCommand, self._cli.get_server_command("-v 2 query --status running".split()))
         response: str = self._proxy.query(command).result_string
         response1: str = command.execute(self._db).result_string
         self.assertEqual(response, "\n".join([str(self._jobs[1])]))
         self.assertEqual(response1, "\n".join([str(self._jobs[1])]))
 
     def test_query_memory_empty(self) -> None:
-        command: QueryCommand = cast(QueryCommand, self._cli.get_server_command("query --memory 10 40".split()))
+        command: QueryCommand = cast(QueryCommand, self._cli.get_server_command("-v 2 query --memory 10 40".split()))
         response: str = self._proxy.query(command).result_string
         response1: str = command.execute(self._db).result_string
         self.assertEqual(response, "No jobs satisfy these constraints.")
         self.assertEqual(response1, "No jobs satisfy these constraints.")
 
     def test_query_sresources(self) -> None:
-        command: QueryCommand = cast(QueryCommand, self._cli.get_server_command("query --sr lic,lic1".split()))
+        command: QueryCommand = cast(QueryCommand, self._cli.get_server_command("-v 2 query --sr lic,lic1".split()))
         response: str = self._proxy.query(command).result_string
         response1: str = command.execute(self._db).result_string
         self.assertEqual(response, "\n".join([str(self._jobs[4])]))


### PR DESCRIPTION
This is what an output for one job looks like (if verbosity is not set to 2):
`Job uid: 0, label: lab, status: JobStatus.QUEUED, assigned work machine uid: None`

fixes #190 