### PR TITLE
Fixed suid-python-helper using Python2 on old systems

### DIFF
--- a/data/suid-python-helper/suid-python.c
+++ b/data/suid-python-helper/suid-python.c
@@ -43,7 +43,7 @@
 #define SWITCHES_ALLOWED 0      /* Python switches, such as -i */
 
 #define NOBODY "nobody"
-#define PYTHON "python"
+#define PYTHON "python3"
 #define SAFE_PATH "PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:" \
                   "/usr/sbin:/usr/bin:/usr/X11R6/bin"
 


### PR DESCRIPTION
suid-python-helper defines a string for the Python binary.
On master this string is "python".
While this works fine on recent Linux distributions it does not on older ones.
The reason for this is that the default python version to use on older distributions is Python 2.7.
This PR modifies suid-python-helper to always use Python 3.