### PR TITLE
Fixed effective user being root for admin users

### DIFF
--- a/src/ja/common/proxy/command_handler.py
+++ b/src/ja/common/proxy/command_handler.py
@@ -64,6 +64,8 @@ class CommandHandler(ABC):
         return self._process_command_dict(command_dict, type_name, username)
 
     def _user_is_admin(self, user: str) -> bool:
+        if user == "root":
+            return True
         groups = [g.gr_name for g in grp.getgrall() if user in g.gr_mem]
         return self._admin_group in groups or user == self._admin_group
 

--- a/src/ja/server/proxy/command_handler.py
+++ b/src/ja/server/proxy/command_handler.py
@@ -77,7 +77,8 @@ class ServerCommandHandler(CommandHandler):
 
         command = cast(Type[UserServerCommand], self._user_commands[type_name]).from_dict(command_dict)
         user_command: UserServerCommand = cast(UserServerCommand, command)
-        user_command.effective_user = 0 if self._user_is_admin(user) else pwd.getpwnam(user).pw_uid
+        user_command.effective_user = pwd.getpwnam(user).pw_uid
+        user_command.effective_user_is_admin = self._user_is_admin(user)
         return self._execute_command(user_command)
 
     def _process_command_dict(

--- a/src/ja/user/message/add.py
+++ b/src/ja/user/message/add.py
@@ -37,7 +37,7 @@ class AddCommand(UserServerCommand):
         if job.owner_id == -1:
             job.owner_id = self.effective_user
 
-        if self.effective_user != 0 and self.effective_user != job.owner_id:
+        if not self.effective_user_is_root and self.effective_user != job.owner_id:
             return Response(result_string="Cannot submit jobs for other users.", is_success=False)
 
         db_job_id: DatabaseJobEntry = database.find_job_by_id(job.uid)

--- a/src/ja/user/message/base.py
+++ b/src/ja/user/message/base.py
@@ -6,7 +6,8 @@ from ja.user.config.base import UserConfig
 
 class UserServerCommand(ServerCommand, ABC):
     def __init__(self, config: UserConfig) -> None:
-        self._effective_user: int = 0
+        self._effective_user: int = 99
+        self._effective_user_is_admin: bool = False
         self._config = config
 
     @property
@@ -16,6 +17,18 @@ class UserServerCommand(ServerCommand, ABC):
     @effective_user.setter
     def effective_user(self, user: int) -> None:
         self._effective_user = user
+
+    @property
+    def effective_user_is_admin(self) -> bool:
+        return self._effective_user_is_admin
+
+    @effective_user_is_admin.setter
+    def effective_user_is_admin(self, effective_user_is_admin: bool) -> None:
+        self._effective_user_is_admin = effective_user_is_admin
+
+    @property
+    def effective_user_is_root(self) -> bool:
+        return self._effective_user == 0
 
     @property
     def config(self) -> UserConfig:

--- a/src/ja/user/message/cancel.py
+++ b/src/ja/user/message/cancel.py
@@ -63,7 +63,7 @@ class CancelCommand(UserServerCommand):
         return CancelCommand(label=_label, uid=_uid, config=_config)
 
     def _cancel_job(self, database: ServerDatabase, job: Job, ignore_wrong_permissions: bool) -> bool:
-        has_permissions = (job.owner_id == self.effective_user or self.effective_user == 0)
+        has_permissions = (job.owner_id == self.effective_user or self.effective_user_is_admin)
         if not has_permissions:
             return ignore_wrong_permissions
 

--- a/src/test/integration/test_web_api.py
+++ b/src/test/integration/test_web_api.py
@@ -1,6 +1,7 @@
 from ja.server.config import ServerConfig
 from test.integration.base import IntegrationTest
 from typing import Any, Dict, cast
+from getpass import getuser
 
 import requests
 import yaml
@@ -29,7 +30,7 @@ class TestWebAPI(IntegrationTest):
         machine = self._server._database.get_work_machines()[0]
 
         jobs_uid_dict = {"jobs": [{"job_id": job.job.uid} for job in jobs]}
-        self.run_query("v1/user/root/jobs", 200, jobs_uid_dict)
+        self.run_query("v1/user/%s/jobs" % getuser(), 200, jobs_uid_dict)
 
         workload = {
             "machines": [{

--- a/src/test/user/cli.py
+++ b/src/test/user/cli.py
@@ -50,6 +50,8 @@ class CLITest(TestCase):
             self._proxy.add_job(parsed_command)
             parsed_command_db: AddCommand = cast(AddCommand, self._cli.get_server_command(command))
             parsed_command_db.config.job.uid = str(i)
+            parsed_command_db.effective_user = 0
+            parsed_command_db.effective_user_is_admin = True
             parsed_command_db.execute(self._db)
             if i == 1:
                 parsed_command.config.job.status = JobStatus.RUNNING
@@ -125,6 +127,8 @@ class CLITest(TestCase):
 
     def test_cancel_label(self) -> None:
         command: CancelCommand = cast(CancelCommand, self._cli.get_server_command("cancel --label lab".split()))
+        command.effective_user = 0
+        command.effective_user_is_admin = True
         self._proxy.cancel_job(command)
         command.execute(self._db)
         self.assertEqual(self._db.find_job_by_id("0").job.status, JobStatus.CANCELLED)
@@ -137,6 +141,8 @@ class CLITest(TestCase):
 
     def test_cancel_uid(self) -> None:
         command: CancelCommand = cast(CancelCommand, self._cli.get_server_command("cancel --uid 2".split()))
+        command.effective_user = 0
+        command.effective_user_is_admin = True
         self._proxy.cancel_job(command)
         command.execute(self._db)
         self.assertEqual(self._proxy.jobs[2].status, JobStatus.CANCELLED)


### PR DESCRIPTION
Fixes https://github.com/DistributedTaskScheduling/JobAdder/issues/168 .

On master the effective user for users in the jobadder group is set to 0, i.e. root.
This is **not** just a cosmetic issue.
Jobs submitted by users in the jobadder group were run as root, effectively granting root access to all users in the jobadder group.
This PR revises how a user being admin is checked to prevent this.